### PR TITLE
Remove Email Exist validation

### DIFF
--- a/src/Http/Controllers/Auth/LoginController.php
+++ b/src/Http/Controllers/Auth/LoginController.php
@@ -13,7 +13,7 @@ class LoginController extends Controller
     public function __invoke(Request $request): JsonResponse
     {
         $request->validate([
-            'email' => ['required', 'email', 'exists:users,email'],
+            'email' => ['required', 'email'],
             'password' => ['required'],
         ]);
 


### PR DESCRIPTION
In case someone is going to guess a bunch of e-mail adresses you don't want to tell them the e-mail adress does exists but the combination is incorrect.