### PR TITLE
fix: fixing array for collections

### DIFF
--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -539,7 +539,7 @@ class Repository implements RestifySearchable, JsonSerializable
             ->map(fn (Related $related) => $related->resolve($request, $this)->getValue())
             ->map(function (mixed $items) {
                 if ($items instanceof Collection) {
-                    return $items->filter();
+                    return $items->filter()->values();
                 }
 
                 return $items;


### PR DESCRIPTION
## Fixed

- Return a collection with only its values, without any keys or indexes (if it's an associative array). https://github.com/BinarCode/laravel-restify/issues/524