### PR TITLE
Custom namespace support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,9 @@
     "autoload-dev": {
         "psr-4": {
             "Binaryk\\LaravelRestify\\Tests\\": "tests",
-            "Binaryk\\LaravelRestify\\Tests\\Database\\Factories\\": "tests/database/factories"
+            "Binaryk\\LaravelRestify\\Tests\\Database\\Factories\\": "tests/database/factories",
+            "App\\": "tests/Fixtures/App",
+            "CustomNamespace\\": "tests/Fixtures/CustomNamespace"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -72,5 +72,6 @@
                 "Restify": "Binaryk\\LaravelRestify\\RestifyFacade"
             }
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/config/restify.php
+++ b/config/restify.php
@@ -135,6 +135,17 @@ return [
     ],
 
     'repositories' => [
+
+        /*
+         | Specify the path where the repositories will be created.
+         */
+        'path' => app_path('Restify'),
+
+        /*
+         | Specify the namespace for the repositories.
+         */
+        'namespace' => 'App\Restify',
+
         /*
         | Specify either to serialize index meta (policy) information or not. For performance reasons we recommend disabling it.
         */

--- a/config/restify.php
+++ b/config/restify.php
@@ -137,16 +137,6 @@ return [
     'repositories' => [
 
         /*
-         | Specify the path where the repositories will be created.
-         */
-        'path' => app_path('Restify'),
-
-        /*
-         | Specify the namespace for the repositories.
-         */
-        'namespace' => 'App\Restify',
-
-        /*
         | Specify either to serialize index meta (policy) information or not. For performance reasons we recommend disabling it.
         */
         'serialize_index_meta' => false,

--- a/docs-v2/content/en/api/repositories-advanced.md
+++ b/docs-v2/content/en/api/repositories-advanced.md
@@ -146,6 +146,33 @@ public static function collectMiddlewares(RestifyRequest $request): ?Collection
 }
 ```
 
+## Repository registration
+
+Laravel Restify registers all repositories automatically in the App namespace. However, you can register your own repositories from any service provider using the InteractsWithRestifyRepositories trait. Here's an example:
+
+```php
+<?php
+
+namespace MyPackage\Cart;
+
+use Binaryk\LaravelRestify\Traits\InteractsWithRestifyRepositories;
+use Illuminate\Support\ServiceProvider;
+
+class MyPackageCart extends ServiceProvider
+{
+    use InteractsWithRestifyRepositories;
+
+    public function register(): void
+    {
+        $this->loadRestifyFrom(__DIR__.'/Restify', __NAMESPACE__.'\\Restify\\');
+        
+        // The rest of your package's registration code goes here.
+    }
+}
+```
+
+If you want to load Restify from your own service provider, you must use the InteractsWithRestifyRepositories trait in the service provider class. The loadRestifyFrom method takes the path to the directory containing the repositories and the namespace under which the repositories will be registered.
+
 ## Dependency injection
 
 The Laravel [service container](https://laravel.com/docs/7.x/container) is used to resolve all the Laravel Restify

--- a/src/Restify.php
+++ b/src/Restify.php
@@ -143,7 +143,7 @@ class Restify
      */
     public static function repositoriesFrom(string $directory): void
     {
-        $namespace = app()->getNamespace();
+        $namespace = config('restify.repositories.namespace', app()->getNamespace());
 
         $repositories = [];
 
@@ -280,7 +280,7 @@ class Restify
     public static function ensureRepositoriesLoaded(): void
     {
         if (empty(static::$repositories)) {
-            static::repositoriesFrom(app_path('Restify'));
+            static::repositoriesFrom(config('restify.repositories.path', app_path('Restify')));
         }
     }
 }

--- a/src/Restify.php
+++ b/src/Restify.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionException;
 use Symfony\Component\Finder\Finder;
+use XtendLunar\Addons\RestifyApi\Base\RestifyApi;
 
 class Restify
 {
@@ -136,16 +137,13 @@ class Restify
     }
 
     /**
-     * Register all of the repository classes in the given directory.
-     *
+     * Register all repository classes in the given directory and namespace.
      *
      * @throws ReflectionException
      */
-    public static function repositoriesFrom(string $directory): void
+    public static function repositoriesFrom(string $directory, string $namespace): void
     {
-        $namespace = config('restify.repositories.namespace', app()->getNamespace());
-        $basePath = $namespace === 'App\\' ?  app_path() : $directory;
-
+        $basePath = $namespace === 'App\\' ? app_path() : $directory;
         $repositories = [];
 
         if (! is_dir($directory)) {
@@ -281,7 +279,7 @@ class Restify
     public static function ensureRepositoriesLoaded(): void
     {
         if (empty(static::$repositories)) {
-            static::repositoriesFrom(config('restify.repositories.path', app_path('Restify')));
+            static::repositoriesFrom(app_path('Restify'), app()->getNamespace());
         }
     }
 }

--- a/src/Restify.php
+++ b/src/Restify.php
@@ -17,7 +17,6 @@ use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionException;
 use Symfony\Component\Finder\Finder;
-use XtendLunar\Addons\RestifyApi\Base\RestifyApi;
 
 class Restify
 {

--- a/src/Restify.php
+++ b/src/Restify.php
@@ -144,6 +144,7 @@ class Restify
     public static function repositoriesFrom(string $directory): void
     {
         $namespace = config('restify.repositories.namespace', app()->getNamespace());
+        $basePath = $namespace === 'App\\' ?  app_path() : $directory;
 
         $repositories = [];
 
@@ -155,7 +156,7 @@ class Restify
             $repository = $namespace.str_replace(
                 ['/', '.php'],
                 ['\\', ''],
-                Str::after($repository->getPathname(), app_path().DIRECTORY_SEPARATOR)
+                Str::after($repository->getPathname(), $basePath.DIRECTORY_SEPARATOR)
             );
 
             if (is_subclass_of(

--- a/src/RestifyApplicationServiceProvider.php
+++ b/src/RestifyApplicationServiceProvider.php
@@ -39,7 +39,7 @@ class RestifyApplicationServiceProvider extends ServiceProvider
      */
     protected function repositories(): void
     {
-        Restify::repositoriesFrom(config('restify.repositories.path', app_path('Restify')));
+        Restify::repositoriesFrom(app_path('Restify'), app()->getNamespace());
     }
 
     /**

--- a/src/RestifyApplicationServiceProvider.php
+++ b/src/RestifyApplicationServiceProvider.php
@@ -39,7 +39,7 @@ class RestifyApplicationServiceProvider extends ServiceProvider
      */
     protected function repositories(): void
     {
-        Restify::repositoriesFrom(app_path('Restify'));
+        Restify::repositoriesFrom(config('restify.repositories.path', app_path('Restify')));
     }
 
     /**

--- a/src/Traits/InteractsWithRestifyRepositories.php
+++ b/src/Traits/InteractsWithRestifyRepositories.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Traits;
+
+use Binaryk\LaravelRestify\Restify;
+use ReflectionException;
+
+trait InteractsWithRestifyRepositories
+{
+     /**
+     * Register the application's Rest resources.
+     *
+     * @throws ReflectionException
+     */
+    protected function loadRestifyFrom(string $directory, string $namespace): void
+    {
+        Restify::repositoriesFrom(
+            directory: $directory,
+            namespace: $namespace,
+        );
+    }
+}

--- a/tests/Concerns/WithRepositoriesDataProvider.php
+++ b/tests/Concerns/WithRepositoriesDataProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Tests\Concerns;
+
+trait WithRepositoriesDataProvider
+{
+    public static function repositoryPathsFromFixtures(): array
+    {
+        return [
+            [
+                'directory' => realpath(__DIR__.'/../Fixtures/CustomNamespace/PackageA/Restify'),
+                'namespace' => 'CustomNamespace\\PackageA\\Restify\\',
+                'serviceProvider' => 'CustomNamespace\\PackageA\\PackageAServiceProvider',
+            ],
+            [
+                'directory' => realpath(__DIR__.'/../Fixtures/CustomNamespace/PackageB/Restify'),
+                'namespace' => 'CustomNamespace\\PackageB\\Restify\\',
+                'serviceProvider' => 'CustomNamespace\\PackageB\\PackageBServiceProvider',
+            ],
+            [
+                'directory' => realpath(__DIR__.'/../Fixtures/CustomNamespace/PackageC/Restify'),
+                'namespace' => 'CustomNamespace\\PackageC\\Restify\\',
+                'serviceProvider' => 'CustomNamespace\\PackageC\\PackageCServiceProvider',
+            ],
+        ];
+    }
+}

--- a/tests/Controllers/RepositoryLoadedFromServiceProviderTest.php
+++ b/tests/Controllers/RepositoryLoadedFromServiceProviderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Tests\Controllers;
+
+use Binaryk\LaravelRestify\Restify;
+use Binaryk\LaravelRestify\Tests\Concerns\WithRepositoriesDataProvider;
+use Binaryk\LaravelRestify\Tests\IntegrationTestCase;
+
+class RepositoryLoadedFromServiceProviderTest extends IntegrationTestCase
+{
+    use WithRepositoriesDataProvider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Restify::$repositories = [];
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    /** @dataProvider repositoryPathsFromFixtures */
+    public function test_repositories_can_be_loaded_with_service_provider_register_method(
+        string $directory,
+        string $namespace,
+        ?string $serviceProvider = null,
+    ): void
+    {
+        if (!$serviceProvider) {
+            $this->markTestSkipped('No service provider was found in directory '.$directory.' skipping this iteration.');
+        }
+
+        $this->app->register($serviceProvider);
+
+        foreach (Restify::$repositories as $repository) {
+            $route = $repository::route();
+            $this->getJson($route)->assertOk();
+        }
+
+        // Clears repositories so it does not affect other tests.
+        Restify::$repositories = [];
+    }
+}

--- a/tests/Fixtures/App/Restify/UserRepository.php
+++ b/tests/Fixtures/App/Restify/UserRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Restify;
+
+use App\User;
+
+class UserRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository
+{
+    public static string $model = User::class;
+}

--- a/tests/Fixtures/App/User.php
+++ b/tests/Fixtures/App/User.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App;
+
+class User extends \Binaryk\LaravelRestify\Tests\Fixtures\User\User
+{
+
+}

--- a/tests/Fixtures/CustomNamespace/PackageA/PackageAServiceProvider.php
+++ b/tests/Fixtures/CustomNamespace/PackageA/PackageAServiceProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace CustomNamespace\PackageA;
+
+use Binaryk\LaravelRestify\Traits\InteractsWithRestifyRepositories;
+use Illuminate\Support\ServiceProvider;
+
+class PackageAServiceProvider extends ServiceProvider
+{
+    use InteractsWithRestifyRepositories;
+
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->loadRestifyFrom(__DIR__.'/Restify', __NAMESPACE__.'\\Restify\\');
+    }
+}

--- a/tests/Fixtures/CustomNamespace/PackageA/Restify/UserRepository.php
+++ b/tests/Fixtures/CustomNamespace/PackageA/Restify/UserRepository.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CustomNamespace\PackageA\Restify;
+
+class UserRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository
+{
+
+}

--- a/tests/Fixtures/CustomNamespace/PackageB/PackageBServiceProvider.php
+++ b/tests/Fixtures/CustomNamespace/PackageB/PackageBServiceProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace CustomNamespace\PackageB;
+
+use Binaryk\LaravelRestify\Traits\InteractsWithRestifyRepositories;
+use Illuminate\Support\ServiceProvider;
+
+class PackageBServiceProvider extends ServiceProvider
+{
+    use InteractsWithRestifyRepositories;
+
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->loadRestifyFrom(__DIR__.'/Restify', __NAMESPACE__.'\\Restify\\');
+    }
+}

--- a/tests/Fixtures/CustomNamespace/PackageB/Restify/CompanyRepository.php
+++ b/tests/Fixtures/CustomNamespace/PackageB/Restify/CompanyRepository.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CustomNamespace\PackageB\Restify;
+
+class CompanyRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\Company\CompanyRepository
+{
+
+}

--- a/tests/Fixtures/CustomNamespace/PackageB/Restify/UserRepository.php
+++ b/tests/Fixtures/CustomNamespace/PackageB/Restify/UserRepository.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CustomNamespace\PackageB\Restify;
+
+class UserRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository
+{
+
+}

--- a/tests/Fixtures/CustomNamespace/PackageC/PackageCServiceProvider.php
+++ b/tests/Fixtures/CustomNamespace/PackageC/PackageCServiceProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace CustomNamespace\PackageC;
+
+use Binaryk\LaravelRestify\Traits\InteractsWithRestifyRepositories;
+use Illuminate\Support\ServiceProvider;
+
+class PackageCServiceProvider extends ServiceProvider
+{
+    use InteractsWithRestifyRepositories;
+
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->loadRestifyFrom(__DIR__.'/Restify', __NAMESPACE__.'\\Restify\\');
+    }
+}

--- a/tests/Fixtures/CustomNamespace/PackageC/Restify/CommentRepository.php
+++ b/tests/Fixtures/CustomNamespace/PackageC/Restify/CommentRepository.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CustomNamespace\PackageC\Restify;
+
+class CommentRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\Comment\CommentRepository
+{
+
+}

--- a/tests/Fixtures/CustomNamespace/PackageC/Restify/PostRepository.php
+++ b/tests/Fixtures/CustomNamespace/PackageC/Restify/PostRepository.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CustomNamespace\PackageC\Restify;
+
+class PostRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\Post\PostRepository
+{
+
+}

--- a/tests/Fixtures/CustomNamespace/PackageC/Restify/UserRepository.php
+++ b/tests/Fixtures/CustomNamespace/PackageC/Restify/UserRepository.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CustomNamespace\PackageC\Restify;
+
+class UserRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository
+{
+
+}

--- a/tests/Unit/RepositoriesResolvedFromNamespaceTest.php
+++ b/tests/Unit/RepositoriesResolvedFromNamespaceTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Tests\Unit;
+
+use Binaryk\LaravelRestify\Restify;
+use Binaryk\LaravelRestify\Tests\Concerns\WithRepositoriesDataProvider;
+use Binaryk\LaravelRestify\Tests\IntegrationTestCase;
+use Orchestra\Testbench\TestCase;
+
+class RepositoriesResolvedFromNamespaceTest extends IntegrationTestCase
+{
+    use WithRepositoriesDataProvider;
+
+    protected function setUp(): void
+    {
+        TestCase::setUp();
+
+        Restify::$repositories = [];
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    public function test_repository_can_be_resolved_from_app_namespace(): void
+    {
+        Restify::repositoriesFrom(
+            directory: realpath(__DIR__.'/../Fixtures/App/Restify'),
+            namespace: 'App\\Restify\\',
+        );
+
+        $this->assertEquals(
+            expected: 'App\\Restify\\UserRepository',
+            actual: Restify::repositoryForModel('App\\User'),
+        );
+
+        $this->assertContains(
+            'App\\Restify\\UserRepository',
+            Restify::$repositories,
+        );
+
+        $this->assertInstanceOf(
+            expected: 'App\\Restify\\UserRepository',
+            actual: Restify::repository('users'),
+        );
+    }
+
+    /**
+     * @dataProvider repositoryPathsFromFixtures
+     */
+    public function test_repository_can_be_resolved_from_any_namespace(string $directory, string $namespace): void
+    {
+        Restify::repositoriesFrom(
+            directory: $directory,
+            namespace: $namespace,
+        );
+
+        $this->assertCount(
+            expectedCount: count(glob($directory.'/*Repository.php')),
+            haystack: Restify::$repositories,
+        );
+
+        foreach (Restify::$repositories as $repository) {
+            $this->assertInstanceOf(
+                expected: $repository,
+                actual: Restify::repository($repository::uriKey()),
+            );
+        }
+    }
+}


### PR DESCRIPTION
I'm really impressed with Restify and plan to use it for all my API integrations going forward. 

Currently, Restify uses the default namespace "App" for repositories, which means that it only works from the App namespace. However, I'm proposing custom namespace support which will allow you to load Restify from anywhere using the new `InteractsWithRestifyRepositories` trait. 

Here's an example of loading Restify from a service provider:

```php
public function register()
{
    $this->loadViewsFrom(__DIR__.'/../resources/views', 'xtend::page-builder');
    $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'xtend::page-builder');
    $this->loadRestifyFrom(__DIR__.'/Restify', __NAMESPACE__.'\\Restify\\');
}
```

This custom namespace support will be particularly useful for my current project, where I load some API endpoints from the App directory but also want to take full advantage of Restify for new features. By using the new trait, I can easily load Restify from any package.

If you're okay with these changes, I would be happy to document them and also write some tests for this. I plan to contribute a lot more to Restify in the future 🤘