### PR TITLE
Repository default fields

### DIFF
--- a/src/Traits/InteractsWithDefaultFields.php
+++ b/src/Traits/InteractsWithDefaultFields.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Traits;
+
+use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
+
+trait InteractsWithDefaultFields
+{
+    public static array $excludeFields = [];
+
+    public function fields(RestifyRequest $request): array
+    {
+        return $this->getDefaultFields(
+            exclude: static::$excludeFields
+        );
+    }
+
+    public function fieldsForIndex(RestifyRequest $request): array
+    {
+        return $this->fields($request);
+    }
+
+    public function fieldsForShow(RestifyRequest $request): array
+    {
+        return $this->fields($request);
+    }
+
+    public function fieldsForUpdate(RestifyRequest $request): array
+    {
+        return $this->fields($request);
+    }
+
+    public function fieldsForStore(RestifyRequest $request): array
+    {
+        return $this->fields($request);
+    }
+
+    protected function getDefaultFields(array $exclude = []): array
+    {
+        return collect($this->model()->getAttributes())
+            ->filter(fn($attribute, $field) => !in_array($field, $exclude))
+            ->mapWithKeys(function ($value, $key) {
+                $field = field($key);
+                if (collect($this->model()->getCasts())->keys()->contains($key)) {
+                    $field = $field->readOnly();
+                }
+                return [$key => $field];
+            })->all();
+    }
+}


### PR DESCRIPTION
I've created a handy trait that automatically adds default fields to repositories. 
This has been a real time-saver for me, especially since I've had to add more than 20 repositories, and I didn't want to go through the process to add all the fields for each one 😅

@binaryk 
Furthermore, this also integrates smoothly with the presenter. Although I haven't had the chance to submit a PR for this feature yet, you can check out how it works here. https://github.com/xtend-laravel/addon-restify-api/tree/main/src/Restify
