### PR TITLE
docs: Missing key on partial matches array

### DIFF
--- a/docs-v2/content/en/search/basic-filters.md
+++ b/docs-v2/content/en/search/basic-filters.md
@@ -411,7 +411,7 @@ This could be done using the `Binaryk\LaravelRestify\Filters\MatchFilter` class:
 public static function matches(): array
 {
     return [
-        MatchFilter::make()->setType('text')->partial()
+        'title' => MatchFilter::make()->setType('text')->partial()
     ];
 }
 ```


### PR DESCRIPTION
The docs are lacking the key, which results in an error when requesting the `/filter` endpoint and no effect when filtering.