### PR TITLE
fix: `rules` method overrides already defined rules

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -373,7 +373,7 @@ class Field extends OrganicField implements JsonSerializable
      */
     public function rules($rules)
     {
-        $this->rules = ($rules instanceof Rule || is_string($rules) || $rules instanceof Unique) ? func_get_args() : $rules;
+        $this->rules += ($rules instanceof Rule || is_string($rules) || $rules instanceof Unique) ? func_get_args() : $rules;
 
         return $this;
     }


### PR DESCRIPTION
Example: Calling `required()` before `rules()` doesn't add `required` to rules

Related to #567 