### PR TITLE
Cleanup faker from cmd construct

### DIFF
--- a/src/Commands/DevCommand.php
+++ b/src/Commands/DevCommand.php
@@ -2,10 +2,8 @@
 
 namespace Binaryk\LaravelRestify\Commands;
 
-use Faker\Generator as Faker;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
-use Illuminate\Database\ConnectionResolverInterface as Resolver;
 use Illuminate\Support\Str;
 use Symfony\Component\Process\Process;
 
@@ -18,16 +16,6 @@ class DevCommand extends Command
     ';
 
     protected $description = 'Add laravel-restify from a local directory.';
-
-    /** * @var Faker */
-    private $faker;
-
-    public function __construct(Resolver $resolver, Faker $faker)
-    {
-        parent::__construct();
-        $this->resolver = $resolver;
-        $this->faker = $faker;
-    }
 
     public function handle()
     {

--- a/src/Commands/StubCommand.php
+++ b/src/Commands/StubCommand.php
@@ -4,7 +4,6 @@ namespace Binaryk\LaravelRestify\Commands;
 
 use Binaryk\LaravelRestify\Generators\DatabaseGenerator;
 use Doctrine\DBAL\Schema\Column;
-use Faker\Generator as Faker;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Database\ConnectionResolverInterface as Resolver;
@@ -22,20 +21,14 @@ class StubCommand extends Command
     protected $description = 'Based on table definition, will try to seed the table with mock data.';
 
     /**
-     * @var Faker
-     */
-    private $faker;
-
-    /**
      * @var Resolver
      */
     private $resolver;
 
-    public function __construct(Resolver $resolver, Faker $faker)
+    public function __construct(Resolver $resolver)
     {
         parent::__construct();
         $this->resolver = $resolver;
-        $this->faker = $faker;
     }
 
     public function handle()


### PR DESCRIPTION
I had some issue with `php artisan vendor:publish`. It's not working w/o `fakerphp/faker` installed (if removed or running composer with `--no-dev`). I dig a bit out and found i's `DevCommand` and `StubCommand` cmd that are using it on their constructor.

But it doesn't look used.

* `StubCommand` it was moved directly on `DatabaseGenerator`.
* `DevCommand` it doesn't look used at all, `Resolver` is not used either (old copy / paste from `StubCommand`?).

It's potentially a breaking change. If anybody is extending the Command and do use `$faker` it will fail (well, probably low chances anybody is doing that).