### PR TITLE
9.2.0

### DIFF
--- a/docs-v2/content/en/search/advanced-filters.md
+++ b/docs-v2/content/en/search/advanced-filters.md
@@ -364,13 +364,67 @@ The response will look like this:
       "key": "created-after-date-filter",
       "type": "timestamp",
       "options": []
+    },
+    {
+      "key": "email",
+      "type": "value",
+      "description": "Email",
+      "label": "Email",
+      "meta": {
+        "operator": "like"
+      }
     }
   ]
+}
 ```
 
 Along with custom filters, you can also include in the response the primary filters (as matches), by using `?include` query param: 
 
 ```http request
 /api/restify/posts/filters?include=matches,searchables,sortables
+```
+
+## Handling Additional Payload Data in Advanced Filters
+
+In some scenarios, you might want to send additional data beyond the standard key and value in your filter payload. For instance, you may need to specify an operator or a column to apply more complex filtering logic. Laravel Restify Advanced Filters provide a way to handle these additional payload fields using the `$this->rest()` method.
+
+**Example Payload**
+
+Consider the following payload:
+```json
+const filters = btoa(JSON.stringify([
+    {
+        'key': ValueFilter::uriKey(),
+        'value': 'Valid%',
+        'operator' => 'like',
+        'column' => 'description',
+    }
+]));
+
+const response = await axios.get(`api/restify/posts?filters=${filters}`);
+```
+
+In this payload, besides the standard key and value, we are also sending operator and column. The operator specifies the type of SQL operation, and the column specifies the database column to filter.
+
+Using `$this->rest()` to Access Additional Data
+
+To handle these additional fields in your filter class, you need to ensure they are accessible via the `$this->rest()` method. Here is how you can achieve that:
+
+```php
+class ValueFilter extends AdvancedFilter
+{
+    public function filter(RestifyRequest $request, Builder|Relation $query, $value)
+    {
+        $operator = $this->rest('operator');
+        $column = $this->rest('column');
+
+        $query->where($column, $operator, $value);
+    }
+
+    public function rules(Request $request): array
+    {
+        return [];
+    }
+}
 ```
 

--- a/src/Actions/DestructiveAction.php
+++ b/src/Actions/DestructiveAction.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Actions;
 
-abstract class DestructiveAction extends Action
-{
-}
+abstract class DestructiveAction extends Action {}

--- a/src/Bootstrap/Boot.php
+++ b/src/Bootstrap/Boot.php
@@ -10,8 +10,7 @@ class Boot
     public function __construct(
         private Request $request,
         private RoutesBoot $routesBoot,
-    ) {
-    }
+    ) {}
 
     public function boot(): void
     {

--- a/src/Bootstrap/BootRepository.php
+++ b/src/Bootstrap/BootRepository.php
@@ -9,8 +9,7 @@ class BootRepository
     /** * @var Repository */
     public function __construct(
         private string $repository
-    ) {
-    }
+    ) {}
 
     public function boot(): void
     {

--- a/src/Events/AdvancedFiltersApplied.php
+++ b/src/Events/AdvancedFiltersApplied.php
@@ -11,6 +11,5 @@ class AdvancedFiltersApplied
         public Repository $repository,
         public AdvancedFiltersCollection $advancedFiltersCollection,
         public ?string $rawFilters = null,
-    ) {
-    }
+    ) {}
 }

--- a/src/Exceptions/CredentialsDoesntMatch.php
+++ b/src/Exceptions/CredentialsDoesntMatch.php
@@ -7,6 +7,4 @@ use Exception;
 /**
  * @author Eduard Lupacescu <eduard.lupacescu@binarcode.com>
  */
-class CredentialsDoesntMatch extends Exception
-{
-}
+class CredentialsDoesntMatch extends Exception {}

--- a/src/Exceptions/Eloquent/EntityNotFoundException.php
+++ b/src/Exceptions/Eloquent/EntityNotFoundException.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Exceptions\Eloquent;
 
-class EntityNotFoundException extends \Exception
-{
-}
+class EntityNotFoundException extends \Exception {}

--- a/src/Exceptions/PasswordResetException.php
+++ b/src/Exceptions/PasswordResetException.php
@@ -7,6 +7,4 @@ use Exception;
 /**
  * @author Eduard Lupacescu <eduard.lupacescu@binarcode.com>
  */
-class PasswordResetException extends Exception
-{
-}
+class PasswordResetException extends Exception {}

--- a/src/Exceptions/PasswordResetInvalidTokenException.php
+++ b/src/Exceptions/PasswordResetInvalidTokenException.php
@@ -7,6 +7,4 @@ use Exception;
 /**
  * @author Eduard Lupacescu <eduard.lupacescu@binarcode.com>
  */
-class PasswordResetInvalidTokenException extends Exception
-{
-}
+class PasswordResetInvalidTokenException extends Exception {}

--- a/src/Exceptions/UnauthenticateException.php
+++ b/src/Exceptions/UnauthenticateException.php
@@ -7,6 +7,4 @@ use Exception;
 /**
  * @author Eduard Lupacescu <eduard.lupacescu@binarcode.com>
  */
-class UnauthenticateException extends Exception
-{
-}
+class UnauthenticateException extends Exception {}

--- a/src/Exceptions/UnverifiedUser.php
+++ b/src/Exceptions/UnverifiedUser.php
@@ -7,6 +7,4 @@ use Exception;
 /**
  * @author Eduard Lupacescu <eduard.lupacescu@binarcode.com>
  */
-class UnverifiedUser extends Exception
-{
-}
+class UnverifiedUser extends Exception {}

--- a/src/Fields/BaseField.php
+++ b/src/Fields/BaseField.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Fields;
 
-abstract class BaseField
-{
-}
+abstract class BaseField {}

--- a/src/Fields/HasField.php
+++ b/src/Fields/HasField.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Fields;
 
-class HasField extends EagerField
-{
-}
+class HasField extends EagerField {}

--- a/src/Fields/MorphMany.php
+++ b/src/Fields/MorphMany.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Fields;
 
-class MorphMany extends HasMany
-{
-}
+class MorphMany extends HasMany {}

--- a/src/Fields/MorphOne.php
+++ b/src/Fields/MorphOne.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Fields;
 
-class MorphOne extends BelongsTo
-{
-}
+class MorphOne extends BelongsTo {}

--- a/src/Fields/MorphToMany.php
+++ b/src/Fields/MorphToMany.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Fields;
 
-class MorphToMany extends BelongsToMany
-{
-}
+class MorphToMany extends BelongsToMany {}

--- a/src/Filters/AdvancedFilter.php
+++ b/src/Filters/AdvancedFilter.php
@@ -37,5 +37,10 @@ abstract class AdvancedFilter extends Filter
         return data_get($this->dataObject->value, $key, $default);
     }
 
+    protected function rest(?string $key = null, $default = null)
+    {
+        return data_get($this->dataObject->rest, $key, $default);
+    }
+
     abstract public function rules(Request $request): array;
 }

--- a/src/Filters/AdvancedFilterPayloadDataObject.php
+++ b/src/Filters/AdvancedFilterPayloadDataObject.php
@@ -6,9 +6,14 @@ use Spatie\LaravelData\Data;
 
 class AdvancedFilterPayloadDataObject extends Data
 {
+    public array $rest;
+
     public function __construct(
         public string $key,
         public mixed $value,
+        array $rest = []
+
     ) {
+        $this->rest = $rest;
     }
 }

--- a/src/Filters/AdvancedFiltersCollection.php
+++ b/src/Filters/AdvancedFiltersCollection.php
@@ -47,10 +47,17 @@ class AdvancedFiltersCollection extends Collection
 
                 $advancedFilter = clone $advancedFilter;
 
+                $key =  data_get($queryFilter, 'key');
+                $value =  data_get($queryFilter, 'value');
+                unset($queryFilter['key'], $queryFilter['value']);
+
                 return $advancedFilter->resolve($request, $dto = new AdvancedFilterPayloadDataObject(
-                    key: data_get($queryFilter, 'key'),
-                    value: data_get($queryFilter, 'value'),
-                ))->validatePayload($request, $dto);
+                    $key,
+                    $value,
+                    $queryFilter,
+                ))
+                    ->withMeta($queryFilter['meta'] ?? [])
+                    ->validatePayload($request, $dto);
             })
             ->filter();
     }

--- a/src/Filters/AdvancedFiltersCollection.php
+++ b/src/Filters/AdvancedFiltersCollection.php
@@ -47,8 +47,8 @@ class AdvancedFiltersCollection extends Collection
 
                 $advancedFilter = clone $advancedFilter;
 
-                $key =  data_get($queryFilter, 'key');
-                $value =  data_get($queryFilter, 'value');
+                $key = data_get($queryFilter, 'key');
+                $value = data_get($queryFilter, 'value');
                 unset($queryFilter['key'], $queryFilter['value']);
 
                 return $advancedFilter->resolve($request, $dto = new AdvancedFilterPayloadDataObject(

--- a/src/Filters/Filter.php
+++ b/src/Filters/Filter.php
@@ -259,9 +259,7 @@ abstract class Filter implements JsonSerializable
         return $this;
     }
 
-    protected function booted()
-    {
-    }
+    protected function booted() {}
 
     protected function getType(): string
     {

--- a/src/Filters/FilterPayload.php
+++ b/src/Filters/FilterPayload.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Filters;
 
-interface FilterPayload
-{
-}
+interface FilterPayload {}

--- a/src/Filters/FiltersCollection.php
+++ b/src/Filters/FiltersCollection.php
@@ -10,6 +10,4 @@ use Illuminate\Support\Collection;
  *
  * @extends \Illuminate\Support\Collection<TKey, TValue>
  */
-class FiltersCollection extends Collection
-{
-}
+class FiltersCollection extends Collection {}

--- a/src/Filters/PaginationDataObject.php
+++ b/src/Filters/PaginationDataObject.php
@@ -9,6 +9,5 @@ class PaginationDataObject extends Data
     public function __construct(
         public int|string|null $perPage,
         public int|string|null $page,
-    ) {
-    }
+    ) {}
 }

--- a/src/Filters/RelatedQueryCollection.php
+++ b/src/Filters/RelatedQueryCollection.php
@@ -10,6 +10,4 @@ use Illuminate\Support\Collection;
  *
  * @extends \Illuminate\Support\Collection<TKey, TValue>
  */
-class RelatedQueryCollection extends Collection
-{
-}
+class RelatedQueryCollection extends Collection {}

--- a/src/Http/Controllers/RepositoryController.php
+++ b/src/Http/Controllers/RepositoryController.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Http\Controllers;
 
-class RepositoryController extends RestController
-{
-}
+class RepositoryController extends RestController {}

--- a/src/Http/Requests/GlobalSearchRequest.php
+++ b/src/Http/Requests/GlobalSearchRequest.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Http\Requests;
 
-class GlobalSearchRequest extends RestifyRequest
-{
-}
+class GlobalSearchRequest extends RestifyRequest {}

--- a/src/Http/Requests/IndexRepositoryActionRequest.php
+++ b/src/Http/Requests/IndexRepositoryActionRequest.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Http\Requests;
 
-class IndexRepositoryActionRequest extends ActionRequest
-{
-}
+class IndexRepositoryActionRequest extends ActionRequest {}

--- a/src/Http/Requests/ProfileRequestRequest.php
+++ b/src/Http/Requests/ProfileRequestRequest.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Http\Requests;
 
-class ProfileRequestRequest extends RepositoryShowRequest
-{
-}
+class ProfileRequestRequest extends RepositoryShowRequest {}

--- a/src/Http/Requests/RepositoryActionRequest.php
+++ b/src/Http/Requests/RepositoryActionRequest.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Http\Requests;
 
-class RepositoryActionRequest extends ActionRequest
-{
-}
+class RepositoryActionRequest extends ActionRequest {}

--- a/src/Http/Requests/RepositoryDestroyBulkRequest.php
+++ b/src/Http/Requests/RepositoryDestroyBulkRequest.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Http\Requests;
 
-class RepositoryDestroyBulkRequest extends RestifyRequest
-{
-}
+class RepositoryDestroyBulkRequest extends RestifyRequest {}

--- a/src/Http/Requests/RepositoryDestroyRequest.php
+++ b/src/Http/Requests/RepositoryDestroyRequest.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Http\Requests;
 
-class RepositoryDestroyRequest extends RestifyRequest
-{
-}
+class RepositoryDestroyRequest extends RestifyRequest {}

--- a/src/Http/Requests/RepositoryFiltersRequest.php
+++ b/src/Http/Requests/RepositoryFiltersRequest.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Http\Requests;
 
-class RepositoryFiltersRequest extends RestifyRequest
-{
-}
+class RepositoryFiltersRequest extends RestifyRequest {}

--- a/src/Http/Requests/RepositoryGetterRequest.php
+++ b/src/Http/Requests/RepositoryGetterRequest.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Http\Requests;
 
-class RepositoryGetterRequest extends GetterRequest
-{
-}
+class RepositoryGetterRequest extends GetterRequest {}

--- a/src/Http/Requests/RepositoryIndexRequest.php
+++ b/src/Http/Requests/RepositoryIndexRequest.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Http\Requests;
 
-class RepositoryIndexRequest extends RestifyRequest
-{
-}
+class RepositoryIndexRequest extends RestifyRequest {}

--- a/src/Http/Requests/RepositoryPatchRequest.php
+++ b/src/Http/Requests/RepositoryPatchRequest.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Http\Requests;
 
-class RepositoryPatchRequest extends RepositoryUpdateRequest
-{
-}
+class RepositoryPatchRequest extends RepositoryUpdateRequest {}

--- a/src/Http/Requests/RepositoryShowRequest.php
+++ b/src/Http/Requests/RepositoryShowRequest.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Http\Requests;
 
-class RepositoryShowRequest extends RestifyRequest
-{
-}
+class RepositoryShowRequest extends RestifyRequest {}

--- a/src/Http/Requests/RepositoryStoreRequest.php
+++ b/src/Http/Requests/RepositoryStoreRequest.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Http\Requests;
 
-class RepositoryStoreRequest extends RestifyRequest
-{
-}
+class RepositoryStoreRequest extends RestifyRequest {}

--- a/src/Http/Requests/RepositoryUpdateRequest.php
+++ b/src/Http/Requests/RepositoryUpdateRequest.php
@@ -2,6 +2,4 @@
 
 namespace Binaryk\LaravelRestify\Http\Requests;
 
-class RepositoryUpdateRequest extends RestifyRequest
-{
-}
+class RepositoryUpdateRequest extends RestifyRequest {}

--- a/src/Models/LaravelRestifyModel.php
+++ b/src/Models/LaravelRestifyModel.php
@@ -9,6 +9,4 @@ use Illuminate\Database\Eloquent\Model as EloquentModel;
  *
  * @author Eduard Lupacescu <eduard.lupacescu@binarcode.com>
  */
-abstract class LaravelRestifyModel extends EloquentModel
-{
-}
+abstract class LaravelRestifyModel extends EloquentModel {}

--- a/src/Notifications/ForgotPasswordNotification.php
+++ b/src/Notifications/ForgotPasswordNotification.php
@@ -13,8 +13,7 @@ class ForgotPasswordNotification extends Notification implements ShouldQueue
 
     public function __construct(
         public string $url,
-    ) {
-    }
+    ) {}
 
     public function via($notifiable): array
     {

--- a/src/Repositories/Mergeable.php
+++ b/src/Repositories/Mergeable.php
@@ -6,6 +6,4 @@ namespace Binaryk\LaravelRestify\Repositories;
  * Interface Mergeable
  * Determine whatever should or not to merge the model attributes.
  */
-interface Mergeable
-{
-}
+interface Mergeable {}

--- a/src/Repositories/NullModel.php
+++ b/src/Repositories/NullModel.php
@@ -4,6 +4,4 @@ namespace Binaryk\LaravelRestify\Repositories;
 
 use Illuminate\Database\Eloquent\Model;
 
-class NullModel extends Model
-{
-}
+class NullModel extends Model {}

--- a/src/Repositories/RepositoryInstance.php
+++ b/src/Repositories/RepositoryInstance.php
@@ -6,8 +6,7 @@ class RepositoryInstance
 {
     public function __construct(
         public Repository $repository,
-    ) {
-    }
+    ) {}
 
     public function current(): Repository
     {

--- a/src/Repositories/ValidatingTrait.php
+++ b/src/Repositories/ValidatingTrait.php
@@ -191,21 +191,13 @@ trait ValidatingTrait
         //
     }
 
-    protected static function afterStoringValidation(RestifyRequest $request, $validator)
-    {
-    }
+    protected static function afterStoringValidation(RestifyRequest $request, $validator) {}
 
-    protected static function afterStoringBulkValidation(RestifyRequest $request, $validator)
-    {
-    }
+    protected static function afterStoringBulkValidation(RestifyRequest $request, $validator) {}
 
-    protected static function afterUpdatingValidation(RestifyRequest $request, $validator)
-    {
-    }
+    protected static function afterUpdatingValidation(RestifyRequest $request, $validator) {}
 
-    protected static function afterUpdatingBulkValidation(RestifyRequest $request, $validator)
-    {
-    }
+    protected static function afterUpdatingBulkValidation(RestifyRequest $request, $validator) {}
 
     /**
      * @return array

--- a/src/Traits/PerformsRequestValidation.php
+++ b/src/Traits/PerformsRequestValidation.php
@@ -5,6 +5,4 @@ namespace Binaryk\LaravelRestify\Traits;
 /**
  * @author Eduard Lupacescu <eduard.lupacescu@binarcode.com>
  */
-trait PerformsRequestValidation
-{
-}
+trait PerformsRequestValidation {}

--- a/tests/Assertables/AssertableModel.php
+++ b/tests/Assertables/AssertableModel.php
@@ -27,8 +27,7 @@ abstract class AssertableModel
 
     public function __construct(
         protected Model $model,
-    ) {
-    }
+    ) {}
 
     public function first(?Closure $callback = null): Model
     {

--- a/tests/Controllers/RepositoryFilterControllerTest.php
+++ b/tests/Controllers/RepositoryFilterControllerTest.php
@@ -36,15 +36,15 @@ class RepositoryFilterControllerTest extends IntegrationTestCase
             ->assertJson(
                 fn (AssertableJson $json) => $json
                     ->where('data.0.rules.is_active', 'bool')
-                    ->where('data.4.type', 'text')
-                    ->where('data.4.column', 'title')
-                    ->where('data.5.type', 'value')
+                    ->where('data.5.type', 'text')
                     ->where('data.5.column', 'title')
                     ->where('data.6.type', 'value')
-                    ->where('data.6.column', 'id')
+                    ->where('data.6.column', 'title')
+                    ->where('data.7.type', 'value')
+                    ->where('data.7.column', 'id')
                     ->etc()
             )
-            ->assertJsonCount(8, 'data');
+            ->assertJsonCount(9, 'data');
     }
 
     public function test_available_filters_returns_only_matches_sortables_searches(): void

--- a/tests/Feature/Filters/AdvancedFilterTest.php
+++ b/tests/Feature/Filters/AdvancedFilterTest.php
@@ -38,7 +38,7 @@ class AdvancedFilterTest extends IntegrationTestCase
         $this->getJson(PostRepository::route('filters', query: [
             'only' => 'matches,searchables,sortables',
         ]))->assertJson(
-            fn(AssertableJson $json) => $json
+            fn (AssertableJson $json) => $json
                 ->where('data.1.repository.key', 'users')
                 ->where('data.1.repository.label', 'Users')
                 ->where('data.1.repository.display_key', 'id')
@@ -73,7 +73,7 @@ class AdvancedFilterTest extends IntegrationTestCase
             'filters' => $filters,
         ]))
             ->assertJson(
-                fn(AssertableJson $json) => $json
+                fn (AssertableJson $json) => $json
                     ->where('data.0.attributes.title', $expectedTitle)
                     ->etc()
             )
@@ -197,7 +197,7 @@ class AdvancedFilterTest extends IntegrationTestCase
         ]))
             ->assertOk()
             ->assertJson(
-                fn(AssertableJson $json) => $json
+                fn (AssertableJson $json) => $json
                     ->where('data.0.attributes.title', 'Valid post')
                     ->count('data', 1)
                     ->etc()

--- a/tests/Feature/Filters/AdvancedFilterTest.php
+++ b/tests/Feature/Filters/AdvancedFilterTest.php
@@ -10,6 +10,7 @@ use Binaryk\LaravelRestify\Tests\Fixtures\Post\InactiveFilter;
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\Post;
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostRepository;
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\SelectCategoryFilter;
+use Binaryk\LaravelRestify\Tests\Fixtures\Post\ValueFilter;
 use Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository;
 use Binaryk\LaravelRestify\Tests\IntegrationTestCase;
 use Illuminate\Testing\Fluent\AssertableJson;
@@ -37,7 +38,7 @@ class AdvancedFilterTest extends IntegrationTestCase
         $this->getJson(PostRepository::route('filters', query: [
             'only' => 'matches,searchables,sortables',
         ]))->assertJson(
-            fn (AssertableJson $json) => $json
+            fn(AssertableJson $json) => $json
                 ->where('data.1.repository.key', 'users')
                 ->where('data.1.repository.label', 'Users')
                 ->where('data.1.repository.display_key', 'id')
@@ -72,7 +73,7 @@ class AdvancedFilterTest extends IntegrationTestCase
             'filters' => $filters,
         ]))
             ->assertJson(
-                fn (AssertableJson $json) => $json
+                fn(AssertableJson $json) => $json
                     ->where('data.0.attributes.title', $expectedTitle)
                     ->etc()
             )
@@ -196,10 +197,49 @@ class AdvancedFilterTest extends IntegrationTestCase
         ]))
             ->assertOk()
             ->assertJson(
-                fn (AssertableJson $json) => $json
+                fn(AssertableJson $json) => $json
                     ->where('data.0.attributes.title', 'Valid post')
                     ->count('data', 1)
                     ->etc()
             );
+    }
+
+    public function test_filter_can_send_meta(): void
+    {
+        Post::factory()->create([
+            'title' => 'Valid post',
+            'description' => 'Zoo bar post',
+        ]);
+
+        Post::factory()->create([
+            'title' => 'Active post',
+            'description' => 'Foo bar post',
+        ]);
+
+        $filters = base64_encode(json_encode([
+            [
+                'key' => ValueFilter::uriKey(),
+                'value' => 'Valid%',
+                'operator' => 'like',
+                'column' => 'title',
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        $this->getJson(PostRepository::route(query: [
+            'filters' => $filters,
+        ]))->assertJsonCount(1, 'data');
+
+        $filters = base64_encode(json_encode([
+            [
+                'key' => ValueFilter::uriKey(),
+                'value' => 'Valid%',
+                'operator' => 'like',
+                'column' => 'description',
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        $this->getJson(PostRepository::route(query: [
+            'filters' => $filters,
+        ]))->assertJsonCount(0, 'data');
     }
 }

--- a/tests/Fields/FieldTest.php
+++ b/tests/Fields/FieldTest.php
@@ -183,8 +183,7 @@ class FieldTest extends IntegrationTestCase
         $request = new RepositoryStoreRequest([], []);
 
         $request->setRouteResolver(function () use ($request) {
-            return tap(new Route('POST', '/{repository}', function () {
-            }), function (Route $route) use ($request) {
+            return tap(new Route('POST', '/{repository}', function () {}), function (Route $route) use ($request) {
                 $route->bind($request);
                 $route->setParameter('repository', PostRepository::uriKey());
             });
@@ -212,8 +211,7 @@ class FieldTest extends IntegrationTestCase
         $request = new RepositoryStoreRequest([], []);
 
         $request->setRouteResolver(function () use ($request) {
-            return tap(new Route('POST', '/{repository}', function () {
-            }), function (Route $route) use ($request) {
+            return tap(new Route('POST', '/{repository}', function () {}), function (Route $route) use ($request) {
                 $route->bind($request);
                 $route->setParameter('repository', PostRepository::uriKey());
             });
@@ -241,8 +239,7 @@ class FieldTest extends IntegrationTestCase
         $request = new RepositoryStoreRequest([], []);
 
         $request->setRouteResolver(function () use ($request) {
-            return tap(new Route('POST', '/{repository}', function () {
-            }), function (Route $route) use ($request) {
+            return tap(new Route('POST', '/{repository}', function () {}), function (Route $route) use ($request) {
                 $route->bind($request);
                 $route->setParameter('repository', PostRepository::uriKey());
             });
@@ -284,8 +281,7 @@ class FieldTest extends IntegrationTestCase
         $request = new RepositoryUpdateRequest([], []);
 
         $request->setRouteResolver(function () use ($request, $model) {
-            return tap(new Route('PUT', "/{repository}/{$model->id}", function () {
-            }), function (Route $route) use ($request) {
+            return tap(new Route('PUT', "/{repository}/{$model->id}", function () {}), function (Route $route) use ($request) {
                 $route->bind($request);
                 $route->setParameter('repository', PostRepository::uriKey());
             });
@@ -324,8 +320,7 @@ class FieldTest extends IntegrationTestCase
         $request = new RepositoryStoreRequest([], []);
 
         $request->setRouteResolver(function () use ($request) {
-            return tap(new Route('POST', '/{repository}', function () {
-            }), function (Route $route) use ($request) {
+            return tap(new Route('POST', '/{repository}', function () {}), function (Route $route) use ($request) {
                 $route->bind($request);
                 $route->setParameter('repository', PostRepository::uriKey());
             });

--- a/tests/Fixtures/App/User.php
+++ b/tests/Fixtures/App/User.php
@@ -2,6 +2,4 @@
 
 namespace App;
 
-class User extends \Binaryk\LaravelRestify\Tests\Fixtures\User\User
-{
-}
+class User extends \Binaryk\LaravelRestify\Tests\Fixtures\User\User {}

--- a/tests/Fixtures/CustomNamespace/PackageA/Restify/UserRepository.php
+++ b/tests/Fixtures/CustomNamespace/PackageA/Restify/UserRepository.php
@@ -2,6 +2,4 @@
 
 namespace CustomNamespace\PackageA\Restify;
 
-class UserRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository
-{
-}
+class UserRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository {}

--- a/tests/Fixtures/CustomNamespace/PackageB/Restify/CompanyRepository.php
+++ b/tests/Fixtures/CustomNamespace/PackageB/Restify/CompanyRepository.php
@@ -2,6 +2,4 @@
 
 namespace CustomNamespace\PackageB\Restify;
 
-class CompanyRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\Company\CompanyRepository
-{
-}
+class CompanyRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\Company\CompanyRepository {}

--- a/tests/Fixtures/CustomNamespace/PackageB/Restify/UserRepository.php
+++ b/tests/Fixtures/CustomNamespace/PackageB/Restify/UserRepository.php
@@ -2,6 +2,4 @@
 
 namespace CustomNamespace\PackageB\Restify;
 
-class UserRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository
-{
-}
+class UserRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository {}

--- a/tests/Fixtures/CustomNamespace/PackageC/Restify/CommentRepository.php
+++ b/tests/Fixtures/CustomNamespace/PackageC/Restify/CommentRepository.php
@@ -2,6 +2,4 @@
 
 namespace CustomNamespace\PackageC\Restify;
 
-class CommentRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\Comment\CommentRepository
-{
-}
+class CommentRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\Comment\CommentRepository {}

--- a/tests/Fixtures/CustomNamespace/PackageC/Restify/PostRepository.php
+++ b/tests/Fixtures/CustomNamespace/PackageC/Restify/PostRepository.php
@@ -2,6 +2,4 @@
 
 namespace CustomNamespace\PackageC\Restify;
 
-class PostRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\Post\PostRepository
-{
-}
+class PostRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\Post\PostRepository {}

--- a/tests/Fixtures/CustomNamespace/PackageC/Restify/UserRepository.php
+++ b/tests/Fixtures/CustomNamespace/PackageC/Restify/UserRepository.php
@@ -2,6 +2,4 @@
 
 namespace CustomNamespace\PackageC\Restify;
 
-class UserRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository
-{
-}
+class UserRepository extends \Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository {}

--- a/tests/Fixtures/Post/PostRepository.php
+++ b/tests/Fixtures/Post/PostRepository.php
@@ -95,6 +95,7 @@ class PostRepository extends Repository
             SelectCategoryFilter::new(),
             CreatedAfterDateFilter::new(),
             InactiveFilter::new(),
+            ValueFilter::new(),
         ];
     }
 

--- a/tests/Fixtures/Post/ValueFilter.php
+++ b/tests/Fixtures/Post/ValueFilter.php
@@ -10,6 +10,8 @@ use Illuminate\Http\Request;
 
 class ValueFilter extends AdvancedFilter
 {
+    public ?string $column = 'title';
+
     public function filter(RestifyRequest $request, Builder|Relation $query, $value)
     {
         $operator = $this->rest('operator');

--- a/tests/Fixtures/Post/ValueFilter.php
+++ b/tests/Fixtures/Post/ValueFilter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Tests\Fixtures\Post;
+
+use Binaryk\LaravelRestify\Filters\AdvancedFilter;
+use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Http\Request;
+
+class ValueFilter extends AdvancedFilter
+{
+    public function filter(RestifyRequest $request, Builder|Relation $query, $value)
+    {
+        $operator = $this->rest('operator');
+        $column = $this->rest('column');
+
+        $query->where($column, $operator, $value);
+    }
+
+    public function rules(Request $request): array
+    {
+        return [
+            'is_active' => 'required|boolean',
+        ];
+    }
+}

--- a/tests/Fixtures/User/AvatarFile.php
+++ b/tests/Fixtures/User/AvatarFile.php
@@ -4,6 +4,4 @@ namespace Binaryk\LaravelRestify\Tests\Fixtures\User;
 
 use Binaryk\LaravelRestify\Fields\File;
 
-class AvatarFile extends File
-{
-}
+class AvatarFile extends File {}

--- a/tests/Prototypes/Prototypeable.php
+++ b/tests/Prototypes/Prototypeable.php
@@ -20,8 +20,7 @@ abstract class Prototypeable implements JsonSerializable
 
     public function __construct(
         public IntegrationTestCase $test,
-    ) {
-    }
+    ) {}
 
     protected array $attributes = [];
 


### PR DESCRIPTION
## Added

## Handling Additional Payload Data in Advanced Filters

In some scenarios, you might want to send additional data beyond the standard key and value in your filter payload. For instance, you may need to specify an operator or a column to apply more complex filtering logic. Laravel Restify Advanced Filters provide a way to handle these additional payload fields using the `$this->rest()` method.

**Example Payload**

Consider the following payload:
```json
const filters = btoa(JSON.stringify([
    {
        'key': ValueFilter::uriKey(),
        'value': 'Valid%',
        'operator' => 'like',
        'column' => 'description',
    }
]));

const response = await axios.get(`api/restify/posts?filters=${filters}`);
```

In this payload, besides the standard key and value, we are also sending operator and column. The operator specifies the type of SQL operation, and the column specifies the database column to filter.

Using `$this->rest()` to Access Additional Data

To handle these additional fields in your filter class, you need to ensure they are accessible via the `$this->rest()` method. Here is how you can achieve that:

```php
class ValueFilter extends AdvancedFilter
{
    public function filter(RestifyRequest $request, Builder|Relation $query, $value)
    {
        $operator = $this->rest('operator');
        $column = $this->rest('column');

        $query->where($column, $operator, $value);
    }

    public function rules(Request $request): array
    {
        return [];
    }
}
```

