### PR TITLE
9.3.0

### DIFF
--- a/docs-v2/content/en/search/advanced-filters.md
+++ b/docs-v2/content/en/search/advanced-filters.md
@@ -89,6 +89,22 @@ The frontend has to encode into base64 an array of filters. Each filter contains
 
 - `value` - this is optional, and represents the value the advanced filter will as a third argument in the `filter` method
 
+## Apply advanced filters via POST Request (Version 9.3.0+)
+
+Starting from version 9.3.0, Laravel Restify introduces the ability to apply advanced filters using a POST request. This enhancement simplifies the process of sending complex filter payloads without the need for base64 encoding. Now, you can send the filters directly as JSON in the request body:
+
+```javascript
+const filters = [
+    {
+        'key': 'ready-posts-filter',
+        'value': null,
+    }
+];
+
+const  response = await axios.post(`api/restify/posts/apply-restify-advanced-filters`, filters);
+```
+
+
 ### Custom uri key
 
 Since your class names could change along the way, you can define a `$uriKey` property to your filters, so the frontend will use always the same `key` when applying a filter:
@@ -102,6 +118,64 @@ class ReadyPostsFilter extends AdvancedFilter
 
 };
 ```
+
+### Custom title
+
+```php
+class ReadyPostsFilter extends AdvancedFilter 
+{
+    public static $title = 'Ready to publish posts';
+
+    //...
+
+};
+```
+
+### Custom description
+
+```php
+class ReadyPostsFilter extends AdvancedFilter 
+{
+    public static $description = 'Filter all posts that are ready to publish';
+
+    //...
+
+};
+```
+
+### Custom meta
+
+```php
+class ReadyPostsFilter extends AdvancedFilter 
+{
+   public function meta(): array
+   {
+      return [
+          'icon' => 'icon',
+          'color' => 'red',
+          'operators' => [
+              'like' => 'Like', 
+              'eq' => 'Equal', 
+          ]
+      ];
+   } 
+};
+```
+
+Meta will be rendered key/value in the frontend:
+
+```json
+{
+    ...
+    "icon": "icon",
+    "color": "red",
+    "operators": {
+        "like": "Like",
+        "eq": "Equal"
+    }
+}
+```
+
 ### Advanced filter value
 
 The third argument of the `filter` method is the raw value send by the frontend. Sometimes it might be an array, so you have to get the value using array access: 
@@ -392,16 +466,16 @@ In some scenarios, you might want to send additional data beyond the standard ke
 
 Consider the following payload:
 ```json
-const filters = btoa(JSON.stringify([
+const filters = [
     {
         'key': ValueFilter::uriKey(),
         'value': 'Valid%',
         'operator' => 'like',
         'column' => 'description',
     }
-]));
+];
 
-const response = await axios.get(`api/restify/posts?filters=${filters}`);
+const response = await axios.post(`api/restify/posts/apply-restify-advanced-filters`, filters);
 ```
 
 In this payload, besides the standard key and value, we are also sending operator and column. The operator specifies the type of SQL operation, and the column specifies the database column to filter.

--- a/src/Bootstrap/RoutesDefinition.php
+++ b/src/Bootstrap/RoutesDefinition.php
@@ -22,6 +22,11 @@ class RoutesDefinition
             \Binaryk\LaravelRestify\Http\Controllers\RepositoryFilterController::class
         )->name('filters.index');
 
+        Route::post(
+            $prefix.'/apply-restify-advanced-filters',
+            \Binaryk\LaravelRestify\Http\Controllers\RepositoryApplyFiltersController::class
+        )->name('filters.apply');
+
         // Actions
         Route::get(
             $prefix.'/actions',

--- a/src/Events/AdvancedFiltersApplied.php
+++ b/src/Events/AdvancedFiltersApplied.php
@@ -10,6 +10,6 @@ class AdvancedFiltersApplied
     public function __construct(
         public Repository $repository,
         public AdvancedFiltersCollection $advancedFiltersCollection,
-        public ?string $rawFilters = null,
+        public array $rawFilters = [],
     ) {}
 }

--- a/src/Filters/AdvancedFiltersCollection.php
+++ b/src/Filters/AdvancedFiltersCollection.php
@@ -2,7 +2,6 @@
 
 namespace Binaryk\LaravelRestify\Filters;
 
-use Binaryk\LaravelRestify\Http\Requests\RepositoryApplyFiltersRequest;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
 use Binaryk\LaravelRestify\Repositories\Repository;
 use Illuminate\Support\Collection;
@@ -17,12 +16,12 @@ class AdvancedFiltersCollection extends Collection
 {
     public function authorized(RestifyRequest $request): self
     {
-        return $this->filter(fn(Filter $filter) => $filter->authorizedToSee($request))->values();
+        return $this->filter(fn (Filter $filter) => $filter->authorizedToSee($request))->values();
     }
 
     public function apply(RestifyRequest $request, $query): self
     {
-        return $this->each(fn(AdvancedFilter $filter) => $filter->filter($request, $query, $filter->dataObject->value));
+        return $this->each(fn (AdvancedFilter $filter) => $filter->filter($request, $query, $filter->dataObject->value));
     }
 
     public static function collectQueryFilters(RestifyRequest $request, Repository $repository): self
@@ -36,7 +35,7 @@ class AdvancedFiltersCollection extends Collection
         return static::make($filters)
             ->map(function (array $queryFilter) use ($allowedFilters, $request) {
                 /** * @var AdvancedFilter $advancedFilter */
-                $advancedFilter = $allowedFilters->first(fn(
+                $advancedFilter = $allowedFilters->first(fn (
                     AdvancedFilter $filter
                 ) => $filter::uriKey() === data_get($queryFilter, 'key'));
 

--- a/src/Filters/AdvancedFiltersCollection.php
+++ b/src/Filters/AdvancedFiltersCollection.php
@@ -2,6 +2,7 @@
 
 namespace Binaryk\LaravelRestify\Filters;
 
+use Binaryk\LaravelRestify\Http\Requests\RepositoryApplyFiltersRequest;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
 use Binaryk\LaravelRestify\Repositories\Repository;
 use Illuminate\Support\Collection;
@@ -16,28 +17,26 @@ class AdvancedFiltersCollection extends Collection
 {
     public function authorized(RestifyRequest $request): self
     {
-        return $this->filter(fn (Filter $filter) => $filter->authorizedToSee($request))->values();
+        return $this->filter(fn(Filter $filter) => $filter->authorizedToSee($request))->values();
     }
 
     public function apply(RestifyRequest $request, $query): self
     {
-        return $this->each(fn (AdvancedFilter $filter) => $filter->filter($request, $query, $filter->dataObject->value));
+        return $this->each(fn(AdvancedFilter $filter) => $filter->filter($request, $query, $filter->dataObject->value));
     }
 
     public static function collectQueryFilters(RestifyRequest $request, Repository $repository): self
     {
-        if (! $request->input('filters')) {
+        if (! $filters = $request->filters()) {
             return static::make([]);
         }
-
-        $filters = json_decode(base64_decode($request->input('filters')), true);
 
         $allowedFilters = $repository->collectAdvancedFilters($request);
 
         return static::make($filters)
             ->map(function (array $queryFilter) use ($allowedFilters, $request) {
                 /** * @var AdvancedFilter $advancedFilter */
-                $advancedFilter = $allowedFilters->first(fn (
+                $advancedFilter = $allowedFilters->first(fn(
                     AdvancedFilter $filter
                 ) => $filter::uriKey() === data_get($queryFilter, 'key'));
 

--- a/src/Http/Controllers/RepositoryApplyFiltersController.php
+++ b/src/Http/Controllers/RepositoryApplyFiltersController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Http\Controllers;
+
+use Binaryk\LaravelRestify\Http\Requests\RepositoryApplyFiltersRequest;
+
+class RepositoryApplyFiltersController extends RepositoryController
+{
+    public function __invoke(RepositoryApplyFiltersRequest $request)
+    {
+        return $request->repository()->index($request);
+    }
+}

--- a/src/Http/Requests/RepositoryApplyFiltersRequest.php
+++ b/src/Http/Requests/RepositoryApplyFiltersRequest.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Http\Requests;
+
+class RepositoryApplyFiltersRequest extends RestifyRequest {}

--- a/src/Http/Requests/RestifyRequest.php
+++ b/src/Http/Requests/RestifyRequest.php
@@ -70,4 +70,11 @@ class RestifyRequest extends FormRequest
             return app(RelatedDto::class);
         }
     }
+
+    public function filters(): array
+    {
+        return $this instanceof RepositoryApplyFiltersRequest
+            ? $this->input('filters', [])
+            : json_decode(base64_decode($this->input('filters', [])), true);
+    }
 }

--- a/src/Http/Requests/RestifyRequest.php
+++ b/src/Http/Requests/RestifyRequest.php
@@ -75,6 +75,6 @@ class RestifyRequest extends FormRequest
     {
         return $this instanceof RepositoryApplyFiltersRequest
             ? $this->input('filters', [])
-            : json_decode(base64_decode($this->input('filters', [])), true);
+            : (json_decode(base64_decode($this->input('filters')), true) ?? []);
     }
 }

--- a/src/Services/Search/RepositorySearchService.php
+++ b/src/Services/Search/RepositorySearchService.php
@@ -210,7 +210,7 @@ class RepositorySearchService
                 $repository,
                 AdvancedFiltersCollection::collectQueryFilters($request, $repository)
                     ->apply($request, $query),
-                $request->input('filters'),
+                $request->filters(),
             )
         );
 

--- a/tests/Feature/Filters/AdvancedFilterTest.php
+++ b/tests/Feature/Filters/AdvancedFilterTest.php
@@ -38,7 +38,7 @@ class AdvancedFilterTest extends IntegrationTestCase
         $this->getJson(PostRepository::route('filters', query: [
             'only' => 'matches,searchables,sortables',
         ]))->assertJson(
-            fn(AssertableJson $json) => $json
+            fn (AssertableJson $json) => $json
                 ->where('data.1.repository.key', 'users')
                 ->where('data.1.repository.label', 'Users')
                 ->where('data.1.repository.display_key', 'id')
@@ -73,7 +73,7 @@ class AdvancedFilterTest extends IntegrationTestCase
             'filters' => $filters,
         ]))
             ->assertJson(
-                fn(AssertableJson $json) => $json
+                fn (AssertableJson $json) => $json
                     ->where('data.0.attributes.title', $expectedTitle)
                     ->etc()
             )
@@ -197,7 +197,7 @@ class AdvancedFilterTest extends IntegrationTestCase
         ]))
             ->assertOk()
             ->assertJson(
-                fn(AssertableJson $json) => $json
+                fn (AssertableJson $json) => $json
                     ->where('data.0.attributes.title', 'Valid post')
                     ->count('data', 1)
                     ->etc()

--- a/tests/Feature/Filters/AdvancedFilterTest.php
+++ b/tests/Feature/Filters/AdvancedFilterTest.php
@@ -38,7 +38,7 @@ class AdvancedFilterTest extends IntegrationTestCase
         $this->getJson(PostRepository::route('filters', query: [
             'only' => 'matches,searchables,sortables',
         ]))->assertJson(
-            fn (AssertableJson $json) => $json
+            fn(AssertableJson $json) => $json
                 ->where('data.1.repository.key', 'users')
                 ->where('data.1.repository.label', 'Users')
                 ->where('data.1.repository.display_key', 'id')
@@ -73,7 +73,7 @@ class AdvancedFilterTest extends IntegrationTestCase
             'filters' => $filters,
         ]))
             ->assertJson(
-                fn (AssertableJson $json) => $json
+                fn(AssertableJson $json) => $json
                     ->where('data.0.attributes.title', $expectedTitle)
                     ->etc()
             )
@@ -197,7 +197,7 @@ class AdvancedFilterTest extends IntegrationTestCase
         ]))
             ->assertOk()
             ->assertJson(
-                fn (AssertableJson $json) => $json
+                fn(AssertableJson $json) => $json
                     ->where('data.0.attributes.title', 'Valid post')
                     ->count('data', 1)
                     ->etc()
@@ -241,5 +241,31 @@ class AdvancedFilterTest extends IntegrationTestCase
         $this->getJson(PostRepository::route(query: [
             'filters' => $filters,
         ]))->assertJsonCount(0, 'data');
+    }
+
+    public function test_filter_can_be_sent_in_post_requests(): void
+    {
+        Post::factory()->create([
+            'title' => 'Valid post',
+            'description' => 'Zoo bar post',
+        ]);
+
+        Post::factory()->create([
+            'title' => 'Active post',
+            'description' => 'Foo bar post',
+        ]);
+
+        $filters = [
+            [
+                'key' => ValueFilter::uriKey(),
+                'value' => 'Valid%',
+                'operator' => 'like',
+                'column' => 'title',
+            ],
+        ];
+
+        $this->post(PostRepository::route('apply-restify-advanced-filters'), [
+            'filters' => $filters,
+        ])->assertJsonCount(1, 'data');
     }
 }


### PR DESCRIPTION
## Apply advanced filters via POST Request (Version 9.3.0+)

Starting from version 9.3.0, Laravel Restify introduces the ability to apply advanced filters using a POST request. This enhancement simplifies the process of sending complex filter payloads without the need for base64 encoding. Now, you can send the filters directly as JSON in the request body:

```javascript
const filters = [
    {
        'key': 'ready-posts-filter',
        'value': null,
    }
];

const  response = await axios.post(`api/restify/posts/apply-restify-advanced-filters`, { filters });
```
