### PR TITLE
Fix related key in restifyjsSerialize

### DIFF
--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -1126,7 +1126,7 @@ class Repository implements JsonSerializable, RestifySearchable
     {
         return [
             'uriKey' => static::uriKey(),
-            'related' => static::collectFilters('matches'),
+            'related' => static::collectRelated(),
             'sort' => static::collectFilters('sortables'),
             'match' => static::collectFilters('matches'),
             'searchables' => static::collectFilters('searchables'),


### PR DESCRIPTION
Fixed an error referencing the value of the key related array in the restifyjsSerialize function from static::collectFilters('matches') to static::collectRelated()