### PR TITLE
10.4.0

### DIFF
--- a/docs-v3/content/docs/6.mcp/3.fields.md
+++ b/docs-v3/content/docs/6.mcp/3.fields.md
@@ -473,6 +473,176 @@ Perfect for n8n workflows where files are extracted from emails:
 
 The file will be stored as `expense_receipts/123/Invoice_ABC_Company_Jan_2024.pdf` and the `receipt_filename` column will contain `Invoice_ABC_Company_Jan_2024.pdf`.
 
+## Base64 File Field
+
+The `Base64File` field handles base64-encoded file data, perfect for modern frontend applications that send images as data URIs (signature pads, image editors, webcam captures, canvas-based drawing).
+
+### Basic Usage
+
+```php
+use Binaryk\LaravelRestify\Fields\Base64File;
+
+class SignatureRepository extends Repository
+{
+    public function fields(RestifyRequest $request): array
+    {
+        return [
+            Base64File::make('signature')
+                ->path('signatures/'.$request->user()->id)
+                ->disk('s3'),
+        ];
+    }
+}
+```
+
+### Request Payload
+
+Send base64 data URI strings directly:
+
+```json
+{
+  "signature": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+}
+```
+
+### Features
+
+The `Base64File` field inherits all capabilities from the `File` field:
+
+```php
+Base64File::make('signature')
+    ->path('signatures')                           // Storage subdirectory
+    ->disk('s3')                                   // Storage disk
+    ->storeAs(fn($request) => 'custom-name')       // Custom filename
+    ->storeOriginalName('signature_filename')      // Store filename in column
+    ->storeSize('signature_size')                  // Store file size in column
+    ->resolveUsingTemporaryUrl(true, now()->addMinutes(30))  // S3 signed URLs
+    ->resolveUsingFullUrl()                        // Full storage URL
+    ->prunable()                                   // Delete file when model deleted
+    ->deletable()                                  // Allow manual deletion
+```
+
+### MIME Type Detection
+
+The field automatically detects the file extension from the data URI header:
+
+| Data URI Contains | Extension |
+|-------------------|-----------|
+| `image/png` | `.png` |
+| `image/jpeg` or `image/jpg` | `.jpg` |
+| `image/gif` | `.gif` |
+| `image/webp` | `.webp` |
+| `image/svg+xml` | `.svg` |
+| `application/pdf` | `.pdf` |
+| `text/plain` | `.txt` |
+| `application/json` | `.json` |
+| (default) | `.bin` |
+
+### Fallback Behavior
+
+The `Base64File` field gracefully handles different input types:
+
+- **Base64 data URI**: Decodes and stores as file
+- **URL**: Delegates to parent `File` field behavior (stores URL directly)
+- **File upload**: Delegates to parent `File` field behavior (normal upload)
+- **Empty/null/invalid**: Ignores and preserves existing value
+
+### Custom Filename
+
+Control the stored filename:
+
+```php
+// Static filename (extension auto-appended)
+Base64File::make('signature')
+    ->storeAs('user-signature')  // Stored as: user-signature.png
+
+// From callback (extension auto-appended)
+Base64File::make('signature')
+    ->storeAs(fn($request) => "sig-{$request->user()->id}")
+
+// With extension included
+Base64File::make('signature')
+    ->storeAs('signature.png')  // Used as-is
+```
+
+### Original Name and Size
+
+Track metadata in separate columns:
+
+```php
+Base64File::make('signature')
+    ->storeOriginalName('signature_filename')  // Stores: "base64-upload.png" or custom name
+    ->storeSize('signature_size')              // Stores: decoded file size in bytes
+```
+
+When using `storeAs()` with a callback, the custom filename is used for `storeOriginalName()`.
+
+### Prunable Files
+
+Automatically delete the file when the model is deleted:
+
+```php
+Base64File::make('signature')
+    ->prunable()
+```
+
+When updating a model with a new base64 file and `prunable()` is enabled, the old file is automatically deleted.
+
+### Use Cases
+
+- **Signature pads**: Users draw signatures on canvas
+- **Image editors**: Cropped/edited images from canvas
+- **Webcam captures**: Photos taken in-browser
+- **Screenshot tools**: Clipboard image paste
+- **Avatar generators**: Generated avatars from canvas
+- **Drawing applications**: User-created artwork
+
+### MCP Integration
+
+Hide base64 fields from MCP responses or use optimized fields:
+
+```php
+class SignatureRepository extends Repository
+{
+    public function fields(RestifyRequest $request): array
+    {
+        return [
+            Base64File::make('signature')
+                ->path('signatures')
+                ->resolveUsingTemporaryUrl(true, now()->addMinutes(30))
+                ->hideFromMcp()  // Hide from AI agents
+                ->disk('s3'),
+
+            field('signature_filename')
+                ->description('Filename of the stored signature'),
+        ];
+    }
+
+    // Optimized fields for MCP
+    public function fieldsForMcpShow(RestifyRequest $request): array
+    {
+        return [
+            field('signature_url', fn() => Storage::disk('s3')->temporaryUrl(
+                $this->signature,
+                now()->addMinutes(30)
+            )),
+        ];
+    }
+}
+```
+
+### Raw Base64 Support
+
+The field also supports raw base64 strings without the data URI prefix:
+
+```json
+{
+  "signature": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+}
+```
+
+Note: Without the data URI prefix, the field cannot detect the MIME type and will use `.bin` as the extension. Always prefer the full data URI format.
+
 ## Best Practices
 
 ### 1. Field Selection Strategy

--- a/src/Fields/Base64File.php
+++ b/src/Fields/Base64File.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Fields;
+
+use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
+use Closure;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class Base64File extends File
+{
+    public function fillAttribute(RestifyRequest $request, $model, ?int $bulkRow = null)
+    {
+        if ($this->storeCallback instanceof Closure) {
+            return call_user_func($this->storeCallback, $request, $model, $this->attribute);
+        }
+
+        // Delegate to parent for regular file uploads first
+        if ($this->resolveFileFromRequest($request)) {
+            return parent::fillAttribute($request, $model, $bulkRow);
+        }
+
+        $input = $request->input($this->attribute);
+
+        if (! $input || ! is_string($input)) {
+            return $this;
+        }
+
+        // Delegate to parent for URL inputs
+        if (filter_var($input, FILTER_VALIDATE_URL)) {
+            return parent::fillAttribute($request, $model, $bulkRow);
+        }
+
+        // Handle base64 data
+        if (! $this->isBase64($input)) {
+            return $this;
+        }
+
+        if ($this->isPrunable()) {
+            call_user_func(
+                $this->deleteCallback,
+                $request,
+                $model,
+                $this->getStorageDisk(),
+                $this->getStoragePath()
+            );
+        }
+
+        $result = $this->mergeExtraStorageColumnsForBase64($request, [
+            $this->attribute => $this->storeBase64File($request),
+        ]);
+
+        if (! is_array($result)) {
+            return $model->{$this->attribute} = $result;
+        }
+
+        foreach ($result as $key => $value) {
+            if ($model->isFillable($key)) {
+                $model->{$key} = $value;
+            }
+        }
+
+        return $this;
+    }
+
+    protected function storeBase64File(RestifyRequest $request): string
+    {
+        $base64Data = $request->input($this->attribute);
+        $imageData = $this->decodeBase64($base64Data);
+        $extension = $this->detectExtension($base64Data);
+
+        $filename = $this->resolveFilename($request, $extension);
+        $directory = trim($this->getStorageDir(), '/');
+        $path = $directory ? "{$directory}/{$filename}" : $filename;
+
+        Storage::disk($this->getStorageDisk())->put($path, $imageData);
+
+        return $path;
+    }
+
+    protected function resolveFilename(RestifyRequest $request, string $extension): string
+    {
+        if (! $this->storeAs) {
+            $this->customFilename = null;
+            $this->useCustomFilenameForOriginal = false;
+
+            return Str::uuid().'.'.$extension;
+        }
+
+        $isCallable = is_callable($this->storeAs);
+        $filename = $isCallable
+            ? call_user_func($this->storeAs, $request)
+            : $this->storeAs;
+
+        if (empty($filename)) {
+            $this->customFilename = null;
+            $this->useCustomFilenameForOriginal = false;
+
+            return Str::uuid().'.'.$extension;
+        }
+
+        // Smart extension handling - append if missing
+        if ($extension && ! str_ends_with(strtolower($filename), '.'.$extension)) {
+            $filename = $filename.'.'.$extension;
+        }
+
+        $this->customFilename = $filename;
+        $this->useCustomFilenameForOriginal = $isCallable;
+
+        return $filename;
+    }
+
+    protected function mergeExtraStorageColumnsForBase64(RestifyRequest $request, array $attributes): array
+    {
+        $base64Data = $request->input($this->attribute);
+
+        if ($this->originalNameColumn) {
+            $attributes[$this->originalNameColumn] = ($this->useCustomFilenameForOriginal && $this->customFilename)
+                ? $this->customFilename
+                : $this->detectOriginalName($base64Data);
+        }
+
+        if ($this->sizeColumn) {
+            $attributes[$this->sizeColumn] = $this->calculateDecodedSize($base64Data);
+        }
+
+        return $attributes;
+    }
+
+    protected function detectOriginalName(string $base64Data): string
+    {
+        $extension = $this->detectExtension($base64Data);
+
+        return 'base64-upload.'.$extension;
+    }
+
+    protected function calculateDecodedSize(string $base64Data): int
+    {
+        $parts = explode(',', $base64Data);
+        $encoded = count($parts) > 1 ? $parts[1] : $parts[0];
+
+        return (int) (strlen($encoded) * 3 / 4);
+    }
+
+    protected function isBase64(string $data): bool
+    {
+        // Check for data URI format
+        if (str_starts_with($data, 'data:')) {
+            return true;
+        }
+
+        // Check for raw base64 (no data URI prefix)
+        return base64_encode(base64_decode($data, true)) === $data;
+    }
+
+    protected function decodeBase64(string $base64Data): string
+    {
+        $parts = explode(',', $base64Data);
+
+        return base64_decode(count($parts) > 1 ? $parts[1] : $parts[0]);
+    }
+
+    protected function detectExtension(string $base64Data): string
+    {
+        return match (true) {
+            str_contains($base64Data, 'image/png') => 'png',
+            str_contains($base64Data, 'image/jpeg'), str_contains($base64Data, 'image/jpg') => 'jpg',
+            str_contains($base64Data, 'image/gif') => 'gif',
+            str_contains($base64Data, 'image/webp') => 'webp',
+            str_contains($base64Data, 'image/svg+xml'), str_contains($base64Data, 'image/svg') => 'svg',
+            str_contains($base64Data, 'application/pdf') => 'pdf',
+            str_contains($base64Data, 'text/plain') => 'txt',
+            str_contains($base64Data, 'application/json') => 'json',
+            default => 'bin',
+        };
+    }
+}

--- a/tests/Fields/Base64FileTest.php
+++ b/tests/Fields/Base64FileTest.php
@@ -3,7 +3,6 @@
 namespace Binaryk\LaravelRestify\Tests\Fields;
 
 use Binaryk\LaravelRestify\Fields\Base64File;
-use Binaryk\LaravelRestify\Fields\Image;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
 use Binaryk\LaravelRestify\Tests\Fixtures\User\User;
 use Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository;

--- a/tests/Fields/Base64FileTest.php
+++ b/tests/Fields/Base64FileTest.php
@@ -1,0 +1,470 @@
+<?php
+
+namespace Binaryk\LaravelRestify\Tests\Fields;
+
+use Binaryk\LaravelRestify\Fields\Base64File;
+use Binaryk\LaravelRestify\Fields\Image;
+use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
+use Binaryk\LaravelRestify\Tests\Fixtures\User\User;
+use Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository;
+use Binaryk\LaravelRestify\Tests\IntegrationTestCase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+class Base64FileTest extends IntegrationTestCase
+{
+    protected string $pngBase64 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+    protected string $jpegBase64 = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AVN//2Q==';
+
+    public function test_can_store_base64_file(): void
+    {
+        Storage::fake('customDisk');
+
+        $model = new User;
+        $field = Base64File::make('avatar')->disk('customDisk');
+
+        $request = RestifyRequest::create('/', 'POST', [
+            'avatar' => $this->pngBase64,
+        ]);
+
+        $field->fillAttribute($request, $model);
+
+        $this->assertNotNull($model->avatar);
+        $this->assertStringEndsWith('.png', $model->avatar);
+
+        Storage::disk('customDisk')->assertExists($model->avatar);
+    }
+
+    public function test_can_store_base64_file_with_custom_path(): void
+    {
+        Storage::fake('customDisk');
+
+        $model = new User;
+        $field = Base64File::make('avatar')->disk('customDisk')->path('signatures/user-1');
+
+        $request = RestifyRequest::create('/', 'POST', [
+            'avatar' => $this->pngBase64,
+        ]);
+
+        $field->fillAttribute($request, $model);
+
+        $this->assertNotNull($model->avatar);
+        $this->assertStringStartsWith('signatures/user-1/', $model->avatar);
+        $this->assertStringEndsWith('.png', $model->avatar);
+
+        Storage::disk('customDisk')->assertExists($model->avatar);
+    }
+
+    public function test_can_store_base64_file_with_store_as_string(): void
+    {
+        Storage::fake('customDisk');
+
+        $model = new User;
+        $field = Base64File::make('avatar')
+            ->disk('customDisk')
+            ->storeAs('custom-name');
+
+        $request = RestifyRequest::create('/', 'POST', [
+            'avatar' => $this->pngBase64,
+        ]);
+
+        $field->fillAttribute($request, $model);
+
+        $this->assertEquals('custom-name.png', $model->avatar);
+
+        Storage::disk('customDisk')->assertExists('custom-name.png');
+    }
+
+    public function test_can_store_base64_file_with_store_as_callback(): void
+    {
+        Storage::fake('customDisk');
+
+        $model = new User;
+        $field = Base64File::make('avatar')
+            ->disk('customDisk')
+            ->storeAs(fn () => 'callback-name');
+
+        $request = RestifyRequest::create('/', 'POST', [
+            'avatar' => $this->pngBase64,
+        ]);
+
+        $field->fillAttribute($request, $model);
+
+        $this->assertEquals('callback-name.png', $model->avatar);
+
+        Storage::disk('customDisk')->assertExists('callback-name.png');
+    }
+
+    public function test_can_store_base64_file_with_store_as_including_extension(): void
+    {
+        Storage::fake('customDisk');
+
+        $model = new User;
+        $field = Base64File::make('avatar')
+            ->disk('customDisk')
+            ->storeAs('avatar.png');
+
+        $request = RestifyRequest::create('/', 'POST', [
+            'avatar' => $this->pngBase64,
+        ]);
+
+        $field->fillAttribute($request, $model);
+
+        $this->assertEquals('avatar.png', $model->avatar);
+
+        Storage::disk('customDisk')->assertExists('avatar.png');
+    }
+
+    public function test_can_store_original_name_column(): void
+    {
+        Storage::fake('customDisk');
+
+        $model = new User;
+        $field = Base64File::make('avatar')
+            ->disk('customDisk')
+            ->storeOriginalName('avatar_original');
+
+        $request = RestifyRequest::create('/', 'POST', [
+            'avatar' => $this->pngBase64,
+        ]);
+
+        $field->fillAttribute($request, $model);
+
+        $this->assertEquals('base64-upload.png', $model->avatar_original);
+    }
+
+    public function test_can_store_original_name_from_callback(): void
+    {
+        Storage::fake('customDisk');
+
+        $model = new User;
+        $field = Base64File::make('avatar')
+            ->disk('customDisk')
+            ->storeAs(fn () => 'signature')
+            ->storeOriginalName('avatar_original');
+
+        $request = RestifyRequest::create('/', 'POST', [
+            'avatar' => $this->pngBase64,
+        ]);
+
+        $field->fillAttribute($request, $model);
+
+        $this->assertEquals('signature.png', $model->avatar_original);
+    }
+
+    public function test_can_store_size_column(): void
+    {
+        Storage::fake('customDisk');
+
+        $model = new User;
+        $field = Base64File::make('avatar')
+            ->disk('customDisk')
+            ->storeSize('avatar_size');
+
+        $request = RestifyRequest::create('/', 'POST', [
+            'avatar' => $this->pngBase64,
+        ]);
+
+        $field->fillAttribute($request, $model);
+
+        $this->assertNotNull($model->avatar_size);
+        $this->assertIsInt($model->avatar_size);
+        $this->assertGreaterThan(0, $model->avatar_size);
+    }
+
+    public function test_can_upload_base64_via_repository(): void
+    {
+        Storage::fake('customDisk');
+
+        UserRepository::partialMock()
+            ->shouldReceive('fields')
+            ->andReturn([
+                field('name'),
+                field('avatar_size'),
+                field('avatar_original'),
+
+                Base64File::make('avatar')
+                    ->disk('customDisk')
+                    ->storeOriginalName('avatar_original')
+                    ->storeSize('avatar_size')
+                    ->resolveUsingFullUrl()
+                    ->storeAs('avatar'),
+            ]);
+
+        $user = $this->mockUsers()->first();
+
+        $this->postJson(UserRepository::route($user), [
+            'avatar' => $this->pngBase64,
+        ])->assertOk()->assertJsonFragment([
+            'avatar_original' => 'base64-upload.png',
+            'avatar' => '/storage/avatar.png',
+        ]);
+
+        Storage::disk('customDisk')->assertExists('avatar.png');
+    }
+
+    public function test_detects_jpeg_extension(): void
+    {
+        Storage::fake('customDisk');
+
+        $model = new User;
+        $field = Base64File::make('avatar')->disk('customDisk');
+
+        $request = RestifyRequest::create('/', 'POST', [
+            'avatar' => $this->jpegBase64,
+        ]);
+
+        $field->fillAttribute($request, $model);
+
+        $this->assertStringEndsWith('.jpg', $model->avatar);
+
+        Storage::disk('customDisk')->assertExists($model->avatar);
+    }
+
+    public function test_can_prune_prunable_base64_files(): void
+    {
+        Storage::fake('customDisk');
+
+        $user = tap($this->mockUsers()->first(), function (User $user) {
+            $user->avatar = 'avatar.png';
+            $user->save();
+        });
+
+        Storage::disk('customDisk')->put('avatar.png', 'content');
+        Storage::disk('customDisk')->assertExists('avatar.png');
+
+        UserRepository::partialMock()
+            ->shouldReceive('fields')
+            ->andReturn([
+                Base64File::make('avatar')
+                    ->disk('customDisk')
+                    ->prunable()
+                    ->storeAs('avatar'),
+            ]);
+
+        $this->deleteJson(UserRepository::route($user))
+            ->assertNoContent();
+
+        Storage::disk('customDisk')->assertMissing('avatar.png');
+    }
+
+    public function test_prunable_replaces_existing_file_on_update(): void
+    {
+        Storage::fake('customDisk');
+
+        $user = tap($this->mockUsers()->first(), function (User $user) {
+            $user->avatar = 'old-avatar.png';
+            $user->save();
+        });
+
+        Storage::disk('customDisk')->put('old-avatar.png', 'old content');
+        Storage::disk('customDisk')->assertExists('old-avatar.png');
+
+        UserRepository::partialMock()
+            ->shouldReceive('fields')
+            ->andReturn([
+                Base64File::make('avatar')
+                    ->disk('customDisk')
+                    ->storeAs('new-avatar')
+                    ->prunable(),
+            ]);
+
+        $this->postJson(UserRepository::route($user), [
+            'avatar' => $this->pngBase64,
+        ])->assertOk();
+
+        Storage::disk('customDisk')->assertMissing('old-avatar.png');
+        Storage::disk('customDisk')->assertExists('new-avatar.png');
+    }
+
+    public function test_deletable_base64_file_can_be_deleted(): void
+    {
+        Storage::fake('customDisk');
+
+        $user = tap($this->mockUsers()->first(), function (User $user) {
+            $user->avatar = 'avatar.png';
+            $user->save();
+        });
+
+        Storage::disk('customDisk')->put('avatar.png', 'content');
+        Storage::disk('customDisk')->assertExists('avatar.png');
+
+        UserRepository::partialMock()
+            ->shouldReceive('fields')
+            ->andReturn([
+                Base64File::make('avatar')
+                    ->disk('customDisk')
+                    ->deletable(true),
+            ]);
+
+        $this->deleteJson(UserRepository::route($user->getKey().'/field/avatar'))
+            ->assertNoContent();
+
+        Storage::disk('customDisk')->assertMissing('avatar.png');
+    }
+
+    public function test_falls_back_to_parent_for_url_input(): void
+    {
+        Storage::fake('customDisk');
+
+        UserRepository::partialMock()
+            ->shouldReceive('fields')
+            ->andReturn([
+                Base64File::make('avatar')
+                    ->disk('customDisk'),
+            ]);
+
+        $user = $this->mockUsers()->first();
+
+        $this->postJson(UserRepository::route($user), [
+            'avatar' => 'https://example.com/image.png',
+        ])->assertOk()->assertJsonFragment([
+            'avatar' => 'https://example.com/image.png',
+        ]);
+    }
+
+    public function test_falls_back_to_parent_for_file_upload(): void
+    {
+        Storage::fake('customDisk');
+
+        UserRepository::partialMock()
+            ->shouldReceive('fields')
+            ->andReturn([
+                Base64File::make('avatar')
+                    ->disk('customDisk')
+                    ->resolveUsingFullUrl()
+                    ->storeAs('uploaded-file'),
+            ]);
+
+        $user = $this->mockUsers()->first();
+
+        $this->postJson(UserRepository::route($user), [
+            'avatar' => UploadedFile::fake()->image('test.jpg'),
+        ])->assertOk()->assertJsonFragment([
+            'avatar' => '/storage/uploaded-file.jpg',
+        ]);
+
+        Storage::disk('customDisk')->assertExists('uploaded-file.jpg');
+    }
+
+    public function test_ignores_invalid_input(): void
+    {
+        Storage::fake('customDisk');
+
+        $model = new User;
+        $model->avatar = 'existing.png';
+
+        $field = Base64File::make('avatar')->disk('customDisk');
+
+        $request = RestifyRequest::create('/', 'POST', [
+            'avatar' => 'not-a-valid-base64-or-url',
+        ]);
+
+        $field->fillAttribute($request, $model);
+
+        $this->assertEquals('existing.png', $model->avatar);
+    }
+
+    public function test_ignores_empty_input(): void
+    {
+        Storage::fake('customDisk');
+
+        $model = new User;
+        $model->avatar = 'existing.png';
+
+        $field = Base64File::make('avatar')->disk('customDisk');
+
+        $request = RestifyRequest::create('/', 'POST', [
+            'avatar' => '',
+        ]);
+
+        $field->fillAttribute($request, $model);
+
+        $this->assertEquals('existing.png', $model->avatar);
+    }
+
+    public function test_ignores_null_input(): void
+    {
+        Storage::fake('customDisk');
+
+        $model = new User;
+        $model->avatar = 'existing.png';
+
+        $field = Base64File::make('avatar')->disk('customDisk');
+
+        $request = RestifyRequest::create('/', 'POST', [
+            'avatar' => null,
+        ]);
+
+        $field->fillAttribute($request, $model);
+
+        $this->assertEquals('existing.png', $model->avatar);
+    }
+
+    public function test_can_handle_raw_base64_without_data_uri(): void
+    {
+        Storage::fake('customDisk');
+
+        $model = new User;
+        $rawBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+        $field = Base64File::make('avatar')->disk('customDisk');
+
+        $request = RestifyRequest::create('/', 'POST', [
+            'avatar' => $rawBase64,
+        ]);
+
+        $field->fillAttribute($request, $model);
+
+        $this->assertNotNull($model->avatar);
+        $this->assertStringEndsWith('.bin', $model->avatar);
+
+        Storage::disk('customDisk')->assertExists($model->avatar);
+    }
+
+    public function test_can_store_with_path_and_store_as(): void
+    {
+        Storage::fake('customDisk');
+
+        $model = new User;
+        $field = Base64File::make('avatar')
+            ->disk('customDisk')
+            ->path('users/avatars')
+            ->storeAs('my-avatar');
+
+        $request = RestifyRequest::create('/', 'POST', [
+            'avatar' => $this->pngBase64,
+        ]);
+
+        $field->fillAttribute($request, $model);
+
+        $this->assertEquals('users/avatars/my-avatar.png', $model->avatar);
+
+        Storage::disk('customDisk')->assertExists('users/avatars/my-avatar.png');
+    }
+
+    public function test_resolves_temporary_url(): void
+    {
+        Storage::fake('s3');
+
+        $user = tap($this->mockUsers()->first(), function (User $user) {
+            $user->avatar = 'avatar.png';
+            $user->save();
+        });
+
+        Storage::disk('s3')->put('avatar.png', 'content');
+
+        UserRepository::partialMock()
+            ->shouldReceive('fields')
+            ->andReturn([
+                Base64File::make('avatar')
+                    ->disk('s3')
+                    ->resolveUsingFullUrl(),
+            ]);
+
+        $response = $this->getJson(UserRepository::route($user))->assertOk();
+
+        $this->assertStringContainsString('/storage/avatar.png', $response->json('data.attributes.avatar'));
+    }
+}


### PR DESCRIPTION
 🎉 New Feature: Base64File Field

  Handle base64-encoded file uploads directly in your Restify repositories - perfect for signature pads, canvas drawings, webcam captures, and image editors.

  Usage
```
  use Binaryk\LaravelRestify\Fields\Base64File;

  Base64File::make('signature')
      ->path('signatures')
      ->disk('s3')
      ->storeAs(fn($request) => 'sig-'.now()->timestamp)
      ->resolveUsingTemporaryUrl(true, now()->addMinutes(30));
```
  Request
```
  {
    "signature": "data:image/png;base64,iVBORw0KGgo..."
  }
```
  Features

  - Auto-detects MIME type from data URI (png, jpg, gif, webp, svg, pdf)
  - Inherits all File field capabilities (disk(), path(), storeAs(), prunable(), deletable())
  - Falls back to regular file upload or URL handling when not base64
  - Works with resolveUsingTemporaryUrl() for S3 signed URLs

  Use Cases

  - Signature pads
  - Image editors / croppers
  - Webcam captures
  - Canvas-based drawing apps
  - Screenshot paste functionality