### PR TITLE
Fix path generation for generate:repository command - Fix #712

### DIFF
--- a/src/Commands/GenerateRepositoriesCommand.php
+++ b/src/Commands/GenerateRepositoriesCommand.php
@@ -562,7 +562,7 @@ PHP;
         $namespace = $this->getRepositoryNamespace($modelData);
         $className = $modelData['name'].'Repository';
 
-        return str_replace('App\\', 'app/', str_replace('\\', '/', $namespace)).'/'.$className.'.php';
+        return str_replace('\\', '/', str_replace('App\\', 'app/', $namespace)).'/'.$className.'.php';
     }
 
     protected function getRepositoryFilePath(array $modelData): string


### PR DESCRIPTION
Basically, I reversed the `str_replace` statements which was wrong. Imagine this namespace: `App\Restify\User`.

With the old code:
```php
str_replace('App\\', 'app/', str_replace('\\', '/', $namespace)).'/'.$className.'.php';
```
it would first execute the `str_replace('\\', '/', $namespace))` which results in this string: `App/Restify/User`, meaning the next code execution is useless:
```php
str_replace('App\\', 'app/', 'App/Restify/User')
```