### PR TITLE
fix: Bulk update validation now reports correct error indices

### DIFF
--- a/src/Http/Controllers/RepositoryUpdateBulkController.php
+++ b/src/Http/Controllers/RepositoryUpdateBulkController.php
@@ -10,6 +10,8 @@ class RepositoryUpdateBulkController extends RepositoryController
 {
     public function __invoke(RepositoryUpdateBulkRequest $request)
     {
+        $request->repository()->allowToUpdateBulk($request);
+
         $collection = DB::transaction(function () use ($request) {
             return $request->collectInput()
                 ->each(function (array $item, int $row) use ($request) {
@@ -20,13 +22,7 @@ class RepositoryUpdateBulkController extends RepositoryController
                     /** * @var Repository $repository */
                     $repository = $request->repositoryWith($model);
 
-                    return $repository
-                        ->allowToUpdateBulk($request, $item)
-                        ->updateBulk(
-                            $request,
-                            $id,
-                            $row
-                        );
+                    return $repository->updateBulk($request, $id, $row);
                 });
         });
 

--- a/src/Repositories/ValidatingTrait.php
+++ b/src/Repositories/ValidatingTrait.php
@@ -176,7 +176,7 @@ trait ValidatingTrait
         })->toArray();
 
         return Validator::make(
-            [$plainPayload] ?? $request->all(),
+            $plainPayload ?? $request->all(),
             $on->getUpdatingBulkRules($request),
             $messages
         )->after(function ($validator) use ($request) {

--- a/tests/Controllers/RepositoryUpdateBulkControllerTest.php
+++ b/tests/Controllers/RepositoryUpdateBulkControllerTest.php
@@ -59,4 +59,26 @@ class RepositoryUpdateBulkControllerTest extends IntegrationTestCase
         $this->assertEquals($updatedPost->title, 'Updated first title');
         $this->assertEquals($updatedPost2->title, 'Updated second title');
     }
+
+    public function test_bulk_update_validation_reports_correct_indices(): void
+    {
+        $posts = Post::factory()
+            ->count(3)
+            ->sequence(
+                ['title' => 'First title'],
+                ['title' => 'Second title'],
+                ['title' => 'Third title'],
+            )
+            ->create(['user_id' => 1]);
+
+        $response = $this->postJson(PostRepository::route('bulk/update'), [
+            ['id' => $posts[0]->id, 'title' => 'Valid updated title'],  // Valid (index 0)
+            ['id' => $posts[1]->id, 'title' => null],                   // Invalid (index 1)
+            ['id' => $posts[2]->id, 'title' => null],                   // Invalid (index 2)
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['1.title', '2.title']);
+        $response->assertJsonMissingValidationErrors(['0.title']);
+    }
 }


### PR DESCRIPTION
Previously, bulk update validation always reported errors at index 0                                                                                                                                                         
  regardless of which item failed. This was because validation happened                                                                                                                                                        
  per-item inside the loop, with each item wrapped as [$plainPayload].                                                                                                                                                         
                                                                                                                                                                                                                               
  Changes:                                                                                                                                                                                                                     
  - Move allowToUpdateBulk() call before transaction (like bulk store)                                                                                                                                                         
  - Remove array wrapping in ValidatingTrait::validatorForUpdateBulk()                                                                                                                                                         
  - Add test for correct validation indices                                                                                                                                                                                    
                                                                                                                                                                                                                               
  Now when items at index 1 and 2 fail, errors correctly show as                                                                                                                                                               
  1.field and 2.field instead of 0.field.