### PR TITLE
Fix bulk update validation & authorization per item and their relations

### DIFF
--- a/src/Http/Controllers/RepositoryUpdateBulkController.php
+++ b/src/Http/Controllers/RepositoryUpdateBulkController.php
@@ -10,6 +10,8 @@ class RepositoryUpdateBulkController extends RepositoryController
 {
     public function __invoke(RepositoryUpdateBulkRequest $request)
     {
+        $request->repository()->allowToUpdateBulk($request);
+
         $collection = DB::transaction(function () use ($request) {
             return $request->collectInput()
                 ->each(function (array $item, int $row) use ($request) {
@@ -20,13 +22,7 @@ class RepositoryUpdateBulkController extends RepositoryController
                     /** * @var Repository $repository */
                     $repository = $request->repositoryWith($model);
 
-                    return $repository
-                        ->allowToUpdateBulk($request, $item)
-                        ->updateBulk(
-                            $request,
-                            $id,
-                            $row
-                        );
+                    return $repository->updateBulk($request, $id, $row);
                 });
         });
 

--- a/src/Http/Controllers/RepositoryUpdateBulkController.php
+++ b/src/Http/Controllers/RepositoryUpdateBulkController.php
@@ -10,7 +10,8 @@ class RepositoryUpdateBulkController extends RepositoryController
 {
     public function __invoke(RepositoryUpdateBulkRequest $request)
     {
-        $request->repository()->allowToUpdateBulk($request);
+        // Validate ALL items upfront with correct indices
+        $request->repository()::validatorForUpdateBulk($request)->validate();
 
         $collection = DB::transaction(function () use ($request) {
             return $request->collectInput()
@@ -19,8 +20,11 @@ class RepositoryUpdateBulkController extends RepositoryController
                         $id = $item['id']
                     )->lockForUpdate()->firstOrFail();
 
-                    /** * @var Repository $repository */
+                    /** @var Repository $repository */
                     $repository = $request->repositoryWith($model);
+
+                    // Authorization only (validation done upfront)
+                    $repository->authorizeToUpdateBulk($request);
 
                     return $repository->updateBulk($request, $id, $row);
                 });

--- a/src/Repositories/Repository.php
+++ b/src/Repositories/Repository.php
@@ -1086,7 +1086,7 @@ class Repository implements JsonSerializable, RestifySearchable
     {
         $this->authorizeToUpdateBulk($request);
 
-        $validator = static::validatorForUpdateBulk($request, $this, $payload);
+        $validator = static::validatorForUpdateBulk($request, $this, $payload ? [$payload] : null);
 
         $validator->validate();
 

--- a/src/Repositories/ValidatingTrait.php
+++ b/src/Repositories/ValidatingTrait.php
@@ -176,7 +176,7 @@ trait ValidatingTrait
         })->toArray();
 
         return Validator::make(
-            [$plainPayload] ?? $request->all(),
+            $plainPayload ?? $request->all(),
             $on->getUpdatingBulkRules($request),
             $messages
         )->after(function ($validator) use ($request) {

--- a/tests/Controllers/RepositoryUpdateBulkControllerTest.php
+++ b/tests/Controllers/RepositoryUpdateBulkControllerTest.php
@@ -4,6 +4,7 @@ namespace Binaryk\LaravelRestify\Tests\Controllers;
 
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\Post;
 use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostRepository;
+use Binaryk\LaravelRestify\Tests\Fixtures\User\User;
 use Binaryk\LaravelRestify\Tests\IntegrationTestCase;
 
 class RepositoryUpdateBulkControllerTest extends IntegrationTestCase
@@ -32,32 +33,21 @@ class RepositoryUpdateBulkControllerTest extends IntegrationTestCase
 
     public function test_basic_update_works(): void
     {
-        $post1 = Post::factory()->create([
-            'user_id' => 1,
-            'title' => 'First title',
-        ]);
-        $post2 = Post::factory()->create([
-            'user_id' => 1,
-            'title' => 'Second title',
-        ]);
+        [$post1, $post2] = Post::factory()
+            ->count(2)
+            ->sequence(
+                ['title' => 'First title'],
+                ['title' => 'Second title'],
+            )
+            ->create(['user_id' => 1]);
 
         $this->postJson(PostRepository::route('bulk/update'), [
-            [
-                'id' => $post1->id,
-                'title' => 'Updated first title',
-            ],
-            [
-                'id' => $post2->id,
-                'title' => 'Updated second title',
-            ],
-        ])
-            ->assertOk();
+            ['id' => $post1->id, 'title' => 'Updated first title'],
+            ['id' => $post2->id, 'title' => 'Updated second title'],
+        ])->assertOk();
 
-        $updatedPost = Post::find($post1->id);
-        $updatedPost2 = Post::find($post2->id);
-
-        $this->assertEquals($updatedPost->title, 'Updated first title');
-        $this->assertEquals($updatedPost2->title, 'Updated second title');
+        $this->assertEquals('Updated first title', $post1->fresh()->title);
+        $this->assertEquals('Updated second title', $post2->fresh()->title);
     }
 
     public function test_bulk_update_validation_reports_correct_indices(): void
@@ -80,5 +70,70 @@ class RepositoryUpdateBulkControllerTest extends IntegrationTestCase
         $response->assertUnprocessable();
         $response->assertJsonValidationErrors(['1.title', '2.title']);
         $response->assertJsonMissingValidationErrors(['0.title']);
+    }
+
+    public function test_bulk_update_only_owner_can_update_posts(): void
+    {
+        [$owner, $otherUser] = User::factory()->count(2)->create();
+
+        [$post1, $post2] = Post::factory()
+            ->count(2)
+            ->sequence(
+                ['title' => 'Post 1'],
+                ['title' => 'Post 2'],
+            )
+            ->create(['user_id' => $owner->id]);
+
+        $_SERVER['restify.post.updateBulk.callback'] = static fn (User $user, Post $post): bool => $post->user_id === $user->id;
+
+        $this->actingAs($owner);
+        $this->postJson(PostRepository::route('bulk/update'), [
+            ['id' => $post1->id, 'title' => 'Updated Post 1'],
+            ['id' => $post2->id, 'title' => 'Updated Post 2'],
+        ])->assertOk();
+
+        $this->assertEquals('Updated Post 1', $post1->fresh()->title);
+        $this->assertEquals('Updated Post 2', $post2->fresh()->title);
+
+        $this->actingAs($otherUser);
+        $this->postJson(PostRepository::route('bulk/update'), [
+            ['id' => $post1->id, 'title' => 'Hacked by other'],
+        ])->assertForbidden();
+
+        unset($_SERVER['restify.post.updateBulk.callback']);
+    }
+
+    public function test_bulk_update_policy_checks_post_owner_relation(): void
+    {
+        [$verifiedOwner, $unverifiedOwner, $actingUser] = User::factory()
+            ->count(3)
+            ->sequence(
+                ['email' => 'verified@example.com'],
+                ['email' => 'unverified@test.com'],
+                ['email' => 'acting@test.com'],
+            )
+            ->create();
+
+        [$postByVerified, $postByUnverified] = Post::factory()
+            ->count(2)
+            ->sequence(
+                ['user_id' => $verifiedOwner->id, 'title' => 'Verified Post'],
+                ['user_id' => $unverifiedOwner->id, 'title' => 'Unverified Post'],
+            )
+            ->create();
+
+        $_SERVER['restify.post.updateBulk.callback'] = static fn (User $user, Post $post): bool => str_ends_with($post->user->email, '@example.com');
+
+        $this->actingAs($actingUser);
+
+        $this->postJson(PostRepository::route('bulk/update'), [
+            ['id' => $postByVerified->id, 'title' => 'Updated Verified Post'],
+        ])->assertOk();
+
+        $this->postJson(PostRepository::route('bulk/update'), [
+            ['id' => $postByUnverified->id, 'title' => 'Updated Unverified Post'],
+        ])->assertForbidden();
+
+        unset($_SERVER['restify.post.updateBulk.callback']);
     }
 }

--- a/tests/Controllers/RepositoryUpdateBulkControllerTest.php
+++ b/tests/Controllers/RepositoryUpdateBulkControllerTest.php
@@ -136,26 +136,4 @@ class RepositoryUpdateBulkControllerTest extends IntegrationTestCase
 
         unset($_SERVER['restify.post.updateBulk.callback']);
     }
-
-    public function test_bulk_update_validation_reports_correct_indices(): void
-    {
-        $posts = Post::factory()
-            ->count(3)
-            ->sequence(
-                ['title' => 'First title'],
-                ['title' => 'Second title'],
-                ['title' => 'Third title'],
-            )
-            ->create(['user_id' => 1]);
-
-        $response = $this->postJson(PostRepository::route('bulk/update'), [
-            ['id' => $posts[0]->id, 'title' => 'Valid updated title'],  // Valid (index 0)
-            ['id' => $posts[1]->id, 'title' => null],                   // Invalid (index 1)
-            ['id' => $posts[2]->id, 'title' => null],                   // Invalid (index 2)
-        ]);
-
-        $response->assertUnprocessable();
-        $response->assertJsonValidationErrors(['1.title', '2.title']);
-        $response->assertJsonMissingValidationErrors(['0.title']);
-    }
 }

--- a/tests/Controllers/RepositoryUpdateBulkControllerTest.php
+++ b/tests/Controllers/RepositoryUpdateBulkControllerTest.php
@@ -59,4 +59,26 @@ class RepositoryUpdateBulkControllerTest extends IntegrationTestCase
         $this->assertEquals($updatedPost->title, 'Updated first title');
         $this->assertEquals($updatedPost2->title, 'Updated second title');
     }
+
+    public function test_bulk_update_validation_reports_correct_indices(): void
+    {
+        $posts = Post::factory()
+            ->count(3)
+            ->sequence(
+                ['title' => 'First title'],
+                ['title' => 'Second title'],
+                ['title' => 'Third title'],
+            )
+            ->create(['user_id' => 1]);
+
+        $response = $this->postJson(PostRepository::route('bulk/update'), [
+            ['id' => $posts[0]->id, 'title' => 'Valid updated title'],  // Valid (index 0)
+            ['id' => $posts[1]->id, 'title' => null],                   // Invalid (index 1)
+            ['id' => $posts[2]->id, 'title' => null],                   // Invalid (index 2)
+        ]);
+
+        $response->assertUnprocessable();
+        $response->assertJsonValidationErrors(['1.title', '2.title']);
+        $response->assertJsonMissingValidationErrors(['0.title']);
+    }
 }

--- a/tests/Fixtures/Post/PostPolicy.php
+++ b/tests/Fixtures/Post/PostPolicy.php
@@ -29,8 +29,12 @@ class PostPolicy
         return $_SERVER['restify.post.update'] ?? true;
     }
 
-    public function updateBulk($user): bool
+    public function updateBulk($user, $post = null): bool
     {
+        if (isset($_SERVER['restify.post.updateBulk.callback']) && $post) {
+            return call_user_func($_SERVER['restify.post.updateBulk.callback'], $user, $post);
+        }
+
         return $_SERVER['restify.post.updateBulk'] ?? true;
     }
 


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                   
  - Enable bulk update policies to receive the model for authorization checks                                                                                                                                                  
  - Policies can now check model properties (`$post->user_id`) and relations (`$post->user->email`)                                                                                                                            
                                                                                                                                                                                                                               
  ## Problem                                                                                                                                                                                                                   
  The `updateBulk` policy method was not receiving the `$post` model, preventing authorization checks like:                                                                                                                    
  - Ownership verification: `$post->user_id === $user->id`                                                                                                                                                                     
  - Relation-based checks: `$post->user->email`                                                                                                                                                                                
                                                                                                                                                                                                                               
  ## Solution                                                                                                                                                                                                                  
  - Add `$post` parameter to `PostPolicy::updateBulk()` to receive model from `Gate::check('updateBulk', $this->resource)`                                                                                                     
  - Authorization happens inside the loop after model is loaded, ensuring `$this->resource` contains the actual model                                                                                                          
  - Validate all items upfront (before loop) to preserve correct validation error indices 