### PR TITLE
fix: Add conditional check for ProfileTool usage based on repository …

### DIFF
--- a/src/MCP/Bootstrap/BootMcpTools.php
+++ b/src/MCP/Bootstrap/BootMcpTools.php
@@ -154,10 +154,12 @@ class BootMcpTools
         $tools = ToolsCollection::make();
 
         if ($repository::uriKey() === 'users') {
-            $tools->pushTool(
-                new ProfileTool($repositoryClass),
-                $repository::uriKey()
-            );
+            if (! method_exists($repository, 'canUseForProfile') || call_user_func([$repository, 'canUseForProfile'], request())) {
+                $tools->pushTool(
+                    new ProfileTool($repositoryClass),
+                    $repository::uriKey()
+                );
+            }
         }
 
         if (method_exists($repository, 'mcpAllowsIndex') && $repository->mcpAllowsIndex()) {


### PR DESCRIPTION
## Fix ProfileTool boot condition to respect `canUseForProfile` method

   ### Problem
   `ProfileTool` was being registered in MCP tools regardless of whether repositories defined a `canUseForProfile()` method that returned `false`. This was inconsistent with
  `ProfileController`, which already respects this method to control access.

   ### Solution
   Added the same `canUseForProfile` check used in `ProfileController` (line 39) to `BootMcpTools` (line 156-157). Now `ProfileTool` is only registered if:
   - The `canUseForProfile` method doesn't exist (default allow), OR
   - The method exists and returns `true`

   This ensures consistent behavior between the controller and MCP tool registration.