### PR TITLE
feat: index-friendly sort and search via per-filter case/join modes

### DIFF
--- a/config/restify.php
+++ b/config/restify.php
@@ -181,6 +181,29 @@ return [
         'use_joins_for_belongs_to' => env('RESTIFY_USE_JOINS_FOR_BELONGS_TO', false),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Restify Sort
+    |--------------------------------------------------------------------------
+    */
+    'sort' => [
+        /*
+        |--------------------------------------------------------------------------
+        | Use JOINs for BelongsTo/HasOne Relationship Sorts
+        |--------------------------------------------------------------------------
+        |
+        | When enabled, sortables that target a related column will emit a LEFT JOIN
+        | + ORDER BY <related_table>.<column> instead of an ORDER BY (SELECT ... LIMIT 1)
+        | correlated subquery. Optimizer-friendly; mirrors restify.search.use_joins_for_belongs_to.
+        |
+        | A SortableFilter can override this globally with ->useJoin() or ->useSubquery().
+        |
+        | Default: false (legacy subquery behavior preserved for backward compatibility).
+        |
+        */
+        'use_joins_for_belongs_to' => env('RESTIFY_SORT_USE_JOINS_FOR_BELONGS_TO', false),
+    ],
+
     'repositories' => [
 
         /*

--- a/docs-v3/content/docs/4.search/1.basic-filters.md
+++ b/docs-v3/content/docs/4.search/1.basic-filters.md
@@ -121,16 +121,93 @@ GET: /api/restify/users?search="John Doe"
 
 ## Case-sensitive search
 
-By default, Restify search is case-sensitive. You can change this behavior by changing the configuration:
+By default, Restify search is case-sensitive. You can change this behavior globally:
 
 ```php [restify.php]
-  'search' => [
-      /*
-      | Specify either the search should be case-sensitive or not.
-      */
-      'case_sensitive' => false,
-  ],
+'search' => [
+    /*
+    | Specify either the search should be case-sensitive or not.
+    */
+    'case_sensitive' => false,
+],
 ```
+
+When `case_sensitive` is `false`, every searchable column is wrapped in `UPPER()`:
+
+```sql
+WHERE UPPER(posts.title) LIKE UPPER('%foo%')
+```
+
+This matches case-insensitively at the cost of bypassing any column index. For columns where you know the stored case (numeric, FK ids, codes stored uppercase, status enums stored lowercase), you can opt into index-friendly modes per column.
+
+### Per-field case modes
+
+`SearchableFilter` exposes chainable methods to control how the column expression and the search value are transformed for the `LIKE` comparison. Mix them in the `searchables()` array:
+
+```php
+use Binaryk\LaravelRestify\Filters\SearchableFilter;
+
+public static function searchables(): array
+{
+    return [
+        SearchableFilter::make('gross_amount')->caseRaw(),       // numeric
+        SearchableFilter::make('vendor_code')->upperValue(),     // stored uppercase
+        SearchableFilter::make('status')->lowerValue(),          // stored lowercase
+        SearchableFilter::make('description')->upperBoth(),      // human text
+    ];
+}
+```
+
+Available modes:
+
+| Method | Column | Value | Use when |
+|---|---|---|---|
+| `->caseRaw()` | raw | raw | numerics, FK ids, dates, blind-indexed |
+| `->upperValue()` | raw | UPPER | column always stored UPPER (e.g. vendor codes) |
+| `->lowerValue()` | raw | LOWER | column always stored lowercase (e.g. status enums) |
+| `->upperBoth()` | UPPER | UPPER | legacy case-insensitive (column case unknown) |
+| `->lowerBoth()` | LOWER | LOWER | mirror of `upperBoth` |
+
+`*Value` modes leave the column expression untouched, so any index on that column is still usable. `*Both` modes wrap both sides — case-insensitive but kills indexes.
+
+<alert type="warning">
+
+`upperValue` and `lowerValue` are silent contracts: they assume the column is **always** stored in that case. Rows stored in mixed/opposite case will not match the search.
+
+</alert>
+
+### Custom value transformer
+
+For normalization beyond simple case (trim, unicode fold, digit-strip, etc.), pass any callable to `transform()`:
+
+```php
+SearchableFilter::make('email')->transform(
+    fn (string $v): string => trim(strtolower($v))
+),
+SearchableFilter::make('phone')->transform(
+    fn (string $v): string => preg_replace('/\D/', '', $v)
+),
+```
+
+The column stays raw; the callable controls the value before the `LIKE` comparison.
+
+### Per-field overrides on BelongsTo searchables
+
+`BelongsTo::->searchable([...])` accepts a mix of plain strings and `SearchableFilter` instances, so per-column case modes work for joined searchables too:
+
+```php
+'vendor' => BelongsTo::make('vendor', VendorRepository::class)->searchable([
+    SearchableFilter::make('vendors.code')->upperValue(),  // index-friendly
+    'vendors.name',                                          // default behavior
+]),
+```
+
+### Resolution order
+
+Per searchable column, the resolution is:
+
+1. Instance method (`caseRaw`, `upperValue`, `transform`, etc.) on the `SearchableFilter` — wins.
+2. Otherwise, derive from `restify.search.case_sensitive` — `true` → raw, `false` → UPPER both.
 
 ### Custom search filter
 

--- a/docs-v3/content/docs/4.search/3.sorting.md
+++ b/docs-v3/content/docs/4.search/3.sorting.md
@@ -127,6 +127,65 @@ As you may notice we have typed twice the `users.name` (on the array key, and as
 
 </alert>
 
+## JOIN strategy for sort-by-relation
+
+By default, sorting by a `BelongsTo` or `HasOne` relation column emits a correlated subquery in the `ORDER BY` clause:
+
+```sql
+ORDER BY (SELECT vendors.code FROM vendors WHERE vendors.id = invoices.vendor_id LIMIT 1) ASC
+```
+
+This evaluates per row and prevents the database optimizer from using indexes on the related column. Restify can emit a `LEFT JOIN` instead, which is index-friendly:
+
+```sql
+LEFT JOIN vendors ON invoices.vendor_id = vendors.id
+ORDER BY vendors.code ASC
+```
+
+### Enable globally
+
+Flip the config flag (default `false`) to switch every sort-by-relation to `LEFT JOIN`:
+
+```php [config/restify.php]
+'sort' => [
+    'use_joins_for_belongs_to' => env('RESTIFY_SORT_USE_JOINS_FOR_BELONGS_TO', false),
+],
+```
+
+### Override per filter
+
+Force `LEFT JOIN` (or the legacy subquery) for a single sortable, regardless of the config flag:
+
+```php [PostRepository.php]
+use Binaryk\LaravelRestify\Fields\BelongsTo;
+use Binaryk\LaravelRestify\Filters\SortableFilter;
+
+public static function sorts(): array
+{
+    return [
+        'users.name' => SortableFilter::make()
+            ->setColumn('users.name')
+            ->usingRelation(BelongsTo::make('user', UserRepository::class))
+            ->useJoin(),       // force LEFT JOIN
+            // ->useSubquery() // force legacy subquery
+    ];
+}
+```
+
+Resolution order: per-filter (`useJoin` / `useSubquery`) wins over the config flag, which wins over the legacy subquery default.
+
+<alert type="info">
+
+When search has already left-joined the same related table (because `BelongsTo->searchable([...])` is configured and `restify.search.use_joins_for_belongs_to=true`), the sort path detects the existing join and reuses it — exactly one join per related table.
+
+</alert>
+
+<alert type="warning">
+
+`LEFT JOIN` is supported on `BelongsTo` and `HasOne` only — the two relation types `usingRelation()` accepts. `HasMany`, `MorphTo`, and `BelongsToMany` always use the subquery path; a `LEFT JOIN` would multiply rows and corrupt the result set.
+
+</alert>
+
 ## Sort using closure
 
 If you have a quick sort method, you can use a closure to sort your data:

--- a/docs-v3/content/docs/7.performance/1.performance.md
+++ b/docs-v3/content/docs/7.performance/1.performance.md
@@ -46,6 +46,15 @@ Index meta are policy information related to what actions are allowed on a resou
 
 This will give your application a boost, especially when loading a large amount of resources or relations.
 
+## Index-friendly search and sort
+
+Restify ships with two opt-in optimizations that let database indexes do their work:
+
+- **Sort by relation** can emit a `LEFT JOIN` instead of a per-row correlated subquery. See [JOIN strategy for sort-by-relation](/docs/search/sorting#join-strategy-for-sort-by-relation).
+- **Searchable case modes** let each column declare whether to wrap the column in `UPPER()` / `LOWER()`, transform only the search value, or stay strictly raw. See [Per-field case modes](/docs/search/basic-filters#per-field-case-modes).
+
+Both are off by default and rolled out per-column or per-config — strict backward compatibility.
+
 ## Repository Index Caching
 
 Laravel Restify provides powerful caching for repository index requests to dramatically improve performance for expensive queries with filters, searches, sorts, and pagination. This feature can reduce response times by orders of magnitude for complex API endpoints.

--- a/src/Fields/BelongsTo.php
+++ b/src/Fields/BelongsTo.php
@@ -8,6 +8,7 @@ use Binaryk\LaravelRestify\Filters\SearchableFilter;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 
 class BelongsTo extends EagerField implements Sortable
 {
@@ -50,13 +51,14 @@ class BelongsTo extends EagerField implements Sortable
      */
     public function searchable(...$attributes): self
     {
-        // Handle case where a single array is passed (legacy behavior)
+        // Handle case where a single array is passed (legacy behavior).
+        // flatten(1) preserves SearchableFilter instances inside the array; deeper flattening
+        // would dissolve them into their internal arrays.
         if (count($attributes) === 1 && is_array($attributes[0])) {
             $this->searchablesAttributes = collect($attributes[0])->flatten(1)->all();
             // Also call parent with the first attribute for consistency
             if (! empty($this->searchablesAttributes)) {
-                $first = $this->searchablesAttributes[0];
-                parent::searchable($first instanceof SearchableFilter ? ($first->column() ?? '') : $first);
+                parent::searchable($this->extractColumn($this->searchablesAttributes[0]));
             }
 
             return $this;
@@ -74,7 +76,7 @@ class BelongsTo extends EagerField implements Sortable
         if (count($attributes) === 1 && $attributes[0] instanceof SearchableFilter) {
             $this->searchablesAttributes = [$attributes[0]];
 
-            parent::searchable($attributes[0]->column() ?? '');
+            parent::searchable($this->extractColumn($attributes[0]));
 
             return $this;
         }
@@ -88,9 +90,8 @@ class BelongsTo extends EagerField implements Sortable
         // If it's relationship-specific multiple attributes (all strings), use BelongsTo behavior
         if (count($attributes) > 1 && collect($attributes)->every(fn ($attr) => is_string($attr) || $attr instanceof SearchableFilter)) {
             $this->searchablesAttributes = collect($attributes)->flatten(1)->all();
-            $first = $this->searchablesAttributes[0];
             // Also call parent to maintain consistency with CanSearch trait
-            parent::searchable($first instanceof SearchableFilter ? ($first->column() ?? '') : $first);
+            parent::searchable($this->extractColumn($this->searchablesAttributes[0]));
 
             return $this;
         }
@@ -99,6 +100,24 @@ class BelongsTo extends EagerField implements Sortable
         parent::searchable(...$attributes);
 
         return $this;
+    }
+
+    private function extractColumn(string|SearchableFilter $entry): string
+    {
+        if (is_string($entry)) {
+            return $entry;
+        }
+
+        $column = $entry->column();
+
+        if ($column === null || $column === '') {
+            throw new InvalidArgumentException(
+                'SearchableFilter passed to BelongsTo::searchable() has no column. '
+                .'Pass it as SearchableFilter::make(\'column\') or call setColumn() before passing.'
+            );
+        }
+
+        return $column;
     }
 
     /**

--- a/src/Fields/BelongsTo.php
+++ b/src/Fields/BelongsTo.php
@@ -4,6 +4,7 @@ namespace Binaryk\LaravelRestify\Fields;
 
 use Binaryk\LaravelRestify\Fields\Concerns\Attachable;
 use Binaryk\LaravelRestify\Fields\Contracts\Sortable;
+use Binaryk\LaravelRestify\Filters\SearchableFilter;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
@@ -51,10 +52,11 @@ class BelongsTo extends EagerField implements Sortable
     {
         // Handle case where a single array is passed (legacy behavior)
         if (count($attributes) === 1 && is_array($attributes[0])) {
-            $this->searchablesAttributes = collect($attributes[0])->flatten()->all();
+            $this->searchablesAttributes = collect($attributes[0])->flatten(1)->all();
             // Also call parent with the first attribute for consistency
             if (! empty($this->searchablesAttributes)) {
-                parent::searchable($this->searchablesAttributes[0]);
+                $first = $this->searchablesAttributes[0];
+                parent::searchable($first instanceof SearchableFilter ? ($first->column() ?? '') : $first);
             }
 
             return $this;
@@ -69,6 +71,14 @@ class BelongsTo extends EagerField implements Sortable
             return $this;
         }
 
+        if (count($attributes) === 1 && $attributes[0] instanceof SearchableFilter) {
+            $this->searchablesAttributes = [$attributes[0]];
+
+            parent::searchable($attributes[0]->column() ?? '');
+
+            return $this;
+        }
+
         if (count($attributes) === 1 && is_callable($attributes[0])) {
             $this->searchableCallback = $attributes[0];
 
@@ -76,10 +86,11 @@ class BelongsTo extends EagerField implements Sortable
         }
 
         // If it's relationship-specific multiple attributes (all strings), use BelongsTo behavior
-        if (count($attributes) > 1 && collect($attributes)->every(fn ($attr) => is_string($attr))) {
-            $this->searchablesAttributes = collect($attributes)->flatten()->all();
+        if (count($attributes) > 1 && collect($attributes)->every(fn ($attr) => is_string($attr) || $attr instanceof SearchableFilter)) {
+            $this->searchablesAttributes = collect($attributes)->flatten(1)->all();
+            $first = $this->searchablesAttributes[0];
             // Also call parent to maintain consistency with CanSearch trait
-            parent::searchable($attributes[0]);
+            parent::searchable($first instanceof SearchableFilter ? ($first->column() ?? '') : $first);
 
             return $this;
         }

--- a/src/Filters/Concerns/AppliesRelationJoin.php
+++ b/src/Filters/Concerns/AppliesRelationJoin.php
@@ -16,9 +16,11 @@ trait AppliesRelationJoin
         string $relatedQualifiedKey,
         string $mainTable,
     ): void {
-        // Add JOIN only if it hasn't been added already
+        // Add LEFT JOIN only if a left join on the same table hasn't been added already.
+        // Match join type so an upstream INNER JOIN doesn't suppress our LEFT JOIN — the two
+        // have different semantics (INNER drops rows with no match; LEFT keeps them).
         $exists = collect($query->toBase()->joins ?? [])
-            ->contains(static fn ($join): bool => $join->table === $relatedTable);
+            ->contains(static fn ($join): bool => $join->table === $relatedTable && $join->type === 'left');
 
         if ($exists) {
             return;

--- a/src/Filters/Concerns/AppliesRelationJoin.php
+++ b/src/Filters/Concerns/AppliesRelationJoin.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Binaryk\LaravelRestify\Filters\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+trait AppliesRelationJoin
+{
+    protected function ensureLeftJoin(
+        Builder|Relation $query,
+        string $relatedTable,
+        string $localQualifiedKey,
+        string $relatedQualifiedKey,
+        string $mainTable,
+    ): void {
+        // Add JOIN only if it hasn't been added already
+        $exists = collect($query->toBase()->joins ?? [])
+            ->contains(static fn ($join): bool => $join->table === $relatedTable);
+
+        if ($exists) {
+            return;
+        }
+
+        // Ensure we only select columns from the main table to avoid column conflicts.
+        // Only set select if it hasn't been set already
+        if (empty($query->getQuery()->columns)) {
+            $query->select([$mainTable.'.*']);
+        }
+
+        $query->leftJoin($relatedTable, $localQualifiedKey, '=', $relatedQualifiedKey);
+    }
+}

--- a/src/Filters/SearchableFilter.php
+++ b/src/Filters/SearchableFilter.php
@@ -29,7 +29,9 @@ class SearchableFilter extends Filter
 
     public static function make(...$arguments): static
     {
-        $filter = new static;
+        // Forward all args to the constructor (matches the parent Make trait behavior),
+        // additionally setting the column when the first arg is a string column name.
+        $filter = new static(...$arguments);
 
         if (isset($arguments[0]) && is_string($arguments[0])) {
             $filter->setColumn($arguments[0]);
@@ -252,6 +254,10 @@ class SearchableFilter extends Filter
 
         $columnExpression = $this->wrapColumn($column, $wrap, $connectionType);
 
+        // Pre-existing legacy: wrapped branch hardcodes 'like' (not $likeOperator).
+        // Case-insensitivity comes from the UPPER/LOWER wrap, so on pgsql we don't need ILIKE here.
+        // Note: on pgsql, the RAW branch above uses $likeOperator (= 'ilike'), so caseRaw()/upperValue()/
+        // lowerValue() effectively match case-insensitively on pgsql via ILIKE on the raw column.
         $query->orWhere(
             $relatedModel::selectRaw($columnExpression)
                 ->whereColumn(
@@ -279,7 +285,14 @@ class SearchableFilter extends Filter
     private function resolveBelongsToEntry(string|self $entry, string $relatedTable, bool $useJoins): array
     {
         if ($entry instanceof self) {
-            $column = $entry->column() ?? '';
+            $column = $entry->column();
+
+            if ($column === null || $column === '') {
+                throw new \InvalidArgumentException(
+                    'SearchableFilter inside BelongsTo::searchable() has no column. '
+                    .'Pass it as SearchableFilter::make(\'column\') or call setColumn() before passing.'
+                );
+            }
 
             if ($useJoins && ! str_contains($column, '.')) {
                 $column = $relatedTable.'.'.$column;

--- a/src/Filters/SearchableFilter.php
+++ b/src/Filters/SearchableFilter.php
@@ -4,16 +4,82 @@ namespace Binaryk\LaravelRestify\Filters;
 
 use Binaryk\LaravelRestify\Fields\BelongsTo;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
+use Closure;
 
 class SearchableFilter extends Filter
 {
     public const TYPE = 'searchable';
+
+    public const COLUMN_RAW = 'raw';
+
+    public const COLUMN_UPPER = 'upper';
+
+    public const COLUMN_LOWER = 'lower';
 
     public array $computedColumns = [];
 
     public BelongsTo $belongsToField;
 
     protected $customClosure = null;
+
+    private ?string $columnWrap = null;
+
+    /** @var (callable(string): string)|null */
+    private $valueTransformer = null;
+
+    public function transform(callable $transformer): self
+    {
+        $this->valueTransformer = $transformer;
+        $this->columnWrap ??= self::COLUMN_RAW;
+
+        return $this;
+    }
+
+    public function caseRaw(): self
+    {
+        $this->valueTransformer = static fn (string $value): string => $value;
+        $this->columnWrap = self::COLUMN_RAW;
+
+        return $this;
+    }
+
+    /**
+     * Silent contract: rows stored in mixed/lower case will not match.
+     */
+    public function upperValue(): self
+    {
+        $this->valueTransformer = strtoupper(...);
+        $this->columnWrap = self::COLUMN_RAW;
+
+        return $this;
+    }
+
+    /**
+     * Silent contract: rows stored in mixed/upper case will not match.
+     */
+    public function lowerValue(): self
+    {
+        $this->valueTransformer = strtolower(...);
+        $this->columnWrap = self::COLUMN_RAW;
+
+        return $this;
+    }
+
+    public function upperBoth(): self
+    {
+        $this->valueTransformer = strtoupper(...);
+        $this->columnWrap = self::COLUMN_UPPER;
+
+        return $this;
+    }
+
+    public function lowerBoth(): self
+    {
+        $this->valueTransformer = strtolower(...);
+        $this->columnWrap = self::COLUMN_LOWER;
+
+        return $this;
+    }
 
     public function filter(RestifyRequest $request, $query, $value)
     {
@@ -24,7 +90,7 @@ class SearchableFilter extends Filter
 
         $connectionType = $this->repository->model()->getConnection()->getDriverName();
 
-        $likeOperator = $connectionType == 'pgsql' ? 'ilike' : 'like';
+        $likeOperator = $connectionType === 'pgsql' ? 'ilike' : 'like';
 
         if (isset($this->belongsToField)) {
             if (! $this->belongsToField->authorize($request)) {
@@ -44,79 +110,30 @@ class SearchableFilter extends Filter
             }
 
             // Check if JOINs are enabled in config
-            if (config('restify.search.use_joins_for_belongs_to', false)) {
-                // JOINs are applied at the service level, so we just need to apply search conditions
-                $relatedModel = $this->belongsToField->getRelatedModel($this->repository);
-                $relatedTable = $relatedModel->getTable();
+            $useJoins = (bool) config('restify.search.use_joins_for_belongs_to', false);
+            $relatedTable = $this->belongsToField->getRelatedModel($this->repository)->getTable();
 
-                // Apply search conditions using qualified column names from the joined table
-                collect($this->belongsToField->getSearchables())->each(function (string $attribute) use ($query, $likeOperator, $value, $relatedTable, $connectionType) {
-                    // Check if the attribute is already qualified (contains a dot)
-                    $qualifiedColumn = str_contains($attribute, '.')
-                        ? $attribute
-                        : $relatedTable.'.'.$attribute;
+            collect($this->belongsToField->getSearchables())->each(
+                function (string|self $entry) use ($query, $value, $likeOperator, $connectionType, $useJoins, $relatedTable) {
+                    [$column, $resolver] = $this->resolveBelongsToEntry($entry, $relatedTable, $useJoins);
 
-                    if (! config('restify.search.case_sensitive')) {
-                        $upper = strtoupper($value);
+                    if ($useJoins) {
+                        // JOINs are applied at the service level, here we only emit search conditions
+                        $this->applyValueAndColumn($query, $column, $value, $likeOperator, $connectionType, $resolver);
 
-                        $columnExpression = $connectionType === 'pgsql'
-                            ? "UPPER({$qualifiedColumn}::text)"
-                            : "UPPER({$qualifiedColumn})";
-
-                        $query->orWhereRaw("{$columnExpression} LIKE ?", ['%'.$upper.'%']);
-                    } else {
-                        $query->orWhere($qualifiedColumn, $likeOperator, "%{$value}%");
+                        return;
                     }
-                });
-            } else {
-                // Use the original subquery approach when JOINs are disabled
-                collect($this->belongsToField->getSearchables())->each(function (string $attribute) use ($query, $likeOperator, $value, $connectionType) {
-                    if (! config('restify.search.case_sensitive')) {
-                        $upper = strtoupper($value);
 
-                        $columnExpression = $connectionType === 'pgsql'
-                            ? "UPPER({$attribute}::text)"
-                            : "UPPER({$attribute})";
-
-                        $query->orWhere(
-                            $this->belongsToField->getRelatedModel($this->repository)::selectRaw($columnExpression)
-                                ->whereColumn(
-                                    $this->belongsToField->getQualifiedKey($this->repository),
-                                    $this->belongsToField->getRelatedKey($this->repository)
-                                )
-                                ->take(1),
-                            'like',
-                            "%{$upper}%"
-                        );
-                    } else {
-                        $query->orWhere(
-                            $this->belongsToField->getRelatedModel($this->repository)::select($attribute)
-                                ->whereColumn(
-                                    $this->belongsToField->getQualifiedKey($this->repository),
-                                    $this->belongsToField->getRelatedKey($this->repository)
-                                )
-                                ->take(1),
-                            $likeOperator,
-                            "%{$value}%"
-                        );
-                    }
-                });
-            }
+                    $this->applyBelongsToSubquery($query, $column, $value, $likeOperator, $connectionType, $resolver);
+                }
+            );
 
             return $query;
         }
 
-        if (! config('restify.search.case_sensitive')) {
-            $upper = strtoupper($value);
+        $this->applyValueAndColumn($query, $this->column, $value, $likeOperator, $connectionType, $this);
 
-            $columnExpression = $connectionType === 'pgsql'
-                ? "UPPER({$this->column}::text)"
-                : "UPPER({$this->column})";
-
-            return $query->orWhereRaw("{$columnExpression} LIKE ?", ['%'.$upper.'%']);
-        }
-
-        return $query->orWhere($this->column, $likeOperator, "%{$value}%");
+        return $query;
     }
 
     public function usingBelongsTo(BelongsTo $field): self
@@ -148,5 +165,122 @@ class SearchableFilter extends Filter
     public function hasBelongsTo(): bool
     {
         return isset($this->belongsToField);
+    }
+
+    public function resolvedTransformer(): Closure
+    {
+        if (is_callable($this->valueTransformer)) {
+            return Closure::fromCallable($this->valueTransformer);
+        }
+
+        return config('restify.search.case_sensitive')
+            ? static fn (string $value): string => $value
+            : strtoupper(...);
+    }
+
+    public function resolvedColumnWrap(): string
+    {
+        if ($this->columnWrap !== null) {
+            return $this->columnWrap;
+        }
+
+        return config('restify.search.case_sensitive')
+            ? self::COLUMN_RAW
+            : self::COLUMN_UPPER;
+    }
+
+    private function applyValueAndColumn(
+        $query,
+        string $column,
+        string $value,
+        string $likeOperator,
+        string $connectionType,
+        self $resolver,
+    ): void {
+        $transformedValue = ($resolver->resolvedTransformer())($value);
+        $wrap = $resolver->resolvedColumnWrap();
+
+        if ($wrap === self::COLUMN_RAW) {
+            $query->orWhere($column, $likeOperator, '%'.$transformedValue.'%');
+
+            return;
+        }
+
+        $columnExpression = $this->wrapColumn($column, $wrap, $connectionType);
+
+        $query->orWhereRaw("{$columnExpression} LIKE ?", ['%'.$transformedValue.'%']);
+    }
+
+    private function applyBelongsToSubquery(
+        $query,
+        string $column,
+        string $value,
+        string $likeOperator,
+        string $connectionType,
+        self $resolver,
+    ): void {
+        $transformedValue = ($resolver->resolvedTransformer())($value);
+        $wrap = $resolver->resolvedColumnWrap();
+
+        $relatedModel = $this->belongsToField->getRelatedModel($this->repository);
+
+        if ($wrap === self::COLUMN_RAW) {
+            $query->orWhere(
+                $relatedModel::select($column)
+                    ->whereColumn(
+                        $this->belongsToField->getQualifiedKey($this->repository),
+                        $this->belongsToField->getRelatedKey($this->repository)
+                    )
+                    ->take(1),
+                $likeOperator,
+                '%'.$transformedValue.'%'
+            );
+
+            return;
+        }
+
+        $columnExpression = $this->wrapColumn($column, $wrap, $connectionType);
+
+        $query->orWhere(
+            $relatedModel::selectRaw($columnExpression)
+                ->whereColumn(
+                    $this->belongsToField->getQualifiedKey($this->repository),
+                    $this->belongsToField->getRelatedKey($this->repository)
+                )
+                ->take(1),
+            'like',
+            '%'.$transformedValue.'%'
+        );
+    }
+
+    private function wrapColumn(string $column, string $wrap, string $connectionType): string
+    {
+        $function = $wrap === self::COLUMN_LOWER ? 'LOWER' : 'UPPER';
+
+        return $connectionType === 'pgsql'
+            ? "{$function}({$column}::text)"
+            : "{$function}({$column})";
+    }
+
+    /**
+     * @return array{0: string, 1: self}
+     */
+    private function resolveBelongsToEntry(string|self $entry, string $relatedTable, bool $useJoins): array
+    {
+        if ($entry instanceof self) {
+            $column = $entry->column() ?? '';
+
+            if ($useJoins && ! str_contains($column, '.')) {
+                $column = $relatedTable.'.'.$column;
+            }
+
+            return [$column, $entry];
+        }
+
+        $column = $useJoins
+            ? (str_contains($entry, '.') ? $entry : $relatedTable.'.'.$entry)
+            : $entry;
+
+        return [$column, $this];
     }
 }

--- a/src/Filters/SearchableFilter.php
+++ b/src/Filters/SearchableFilter.php
@@ -27,6 +27,17 @@ class SearchableFilter extends Filter
     /** @var (callable(string): string)|null */
     private $valueTransformer = null;
 
+    public static function make(...$arguments): static
+    {
+        $filter = new static;
+
+        if (isset($arguments[0]) && is_string($arguments[0])) {
+            $filter->setColumn($arguments[0]);
+        }
+
+        return $filter;
+    }
+
     public function transform(callable $transformer): self
     {
         $this->valueTransformer = $transformer;

--- a/src/Filters/SearchableFilter.php
+++ b/src/Filters/SearchableFilter.php
@@ -29,8 +29,6 @@ class SearchableFilter extends Filter
 
     public static function make(...$arguments): static
     {
-        // Forward all args to the constructor (matches the parent Make trait behavior),
-        // additionally setting the column when the first arg is a string column name.
         $filter = new static(...$arguments);
 
         if (isset($arguments[0]) && is_string($arguments[0])) {

--- a/src/Filters/SortableFilter.php
+++ b/src/Filters/SortableFilter.php
@@ -6,6 +6,7 @@ use Binaryk\LaravelRestify\Fields\BelongsTo;
 use Binaryk\LaravelRestify\Fields\Contracts\Sortable;
 use Binaryk\LaravelRestify\Fields\EagerField;
 use Binaryk\LaravelRestify\Fields\HasOne;
+use Binaryk\LaravelRestify\Filters\Concerns\AppliesRelationJoin;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
@@ -14,11 +15,15 @@ use Illuminate\Support\Str;
 
 class SortableFilter extends Filter
 {
+    use AppliesRelationJoin;
+
     public static $uriKey = 'sortables';
 
     public string $direction = 'asc';
 
     private HasOne|BelongsTo $relation;
+
+    private ?bool $useJoin = null;
 
     /**
      * @var callable|Closure
@@ -43,7 +48,10 @@ class SortableFilter extends Filter
                 return $query;
             }
 
-            // This approach could be rewritten using join.
+            if ($this->shouldUseJoin()) {
+                return $this->applyJoinSort($query, $value);
+            }
+
             $query->orderBy(
                 $this->relation->getRelatedModel($this->repository)::select($this->qualifyColumn())
                     ->whereColumn(
@@ -66,6 +74,44 @@ class SortableFilter extends Filter
         $this->relation = $field;
 
         return $this;
+    }
+
+    public function useJoin(): self
+    {
+        $this->useJoin = true;
+
+        return $this;
+    }
+
+    public function useSubquery(): self
+    {
+        $this->useJoin = false;
+
+        return $this;
+    }
+
+    private function shouldUseJoin(): bool
+    {
+        return $this->useJoin ?? (bool) config('restify.sort.use_joins_for_belongs_to', false);
+    }
+
+    private function applyJoinSort(Builder|Relation $query, string $value): Builder|Relation
+    {
+        $relatedModel = $this->relation->getRelatedModel($this->repository);
+        $relatedTable = $relatedModel->getTable();
+        $mainTable = $this->repository->model()->getTable();
+
+        $this->ensureLeftJoin(
+            $query,
+            $relatedTable,
+            $this->relationForeignColumn(),
+            $this->relationRelatedColumn(),
+            $mainTable,
+        );
+
+        $query->orderBy($this->qualifyColumn(), $value);
+
+        return $query;
     }
 
     public function getSortableEager(): ?Sortable

--- a/src/Services/Search/RepositorySearchService.php
+++ b/src/Services/Search/RepositorySearchService.php
@@ -5,6 +5,7 @@ namespace Binaryk\LaravelRestify\Services\Search;
 use Binaryk\LaravelRestify\Events\AdvancedFiltersApplied;
 use Binaryk\LaravelRestify\Fields\EagerField;
 use Binaryk\LaravelRestify\Filters\AdvancedFiltersCollection;
+use Binaryk\LaravelRestify\Filters\Concerns\AppliesRelationJoin;
 use Binaryk\LaravelRestify\Filters\SearchableFilter;
 use Binaryk\LaravelRestify\Filters\SearchablesCollection;
 use Binaryk\LaravelRestify\Http\Requests\RestifyRequest;
@@ -17,6 +18,8 @@ use Throwable;
 
 class RepositorySearchService
 {
+    use AppliesRelationJoin;
+
     /** * @var Repository */
     protected $repository;
 
@@ -299,32 +302,20 @@ class RepositorySearchService
                     // Get relationship details with error handling
                     $relatedModel = $belongsToField->getRelatedModel($this->repository);
                     $relatedTable = $relatedModel->getTable();
+                    $mainTable = $this->repository->model()->getTable();
 
                     $relation = $belongsToField->getRelation($this->repository);
                     $foreignKey = $relation->getForeignKeyName();
                     $ownerKey = $relation->getOwnerKeyName();
 
                     // Build fully qualified column names
-                    $localTableForeignKey = $this->repository->model()->getTable().'.'.$foreignKey;
-                    $relatedTableOwnerKey = $relatedTable.'.'.$ownerKey;
-
-                    // Add JOIN only if it hasn't been added already
-                    $joinAlreadyExists = collect($query->toBase()->joins ?? [])->contains(function ($join) use (
-                        $relatedTable
-                    ) {
-                        return $join->table === $relatedTable;
-                    });
-
-                    if (! $joinAlreadyExists) {
-                        $query->leftJoin($relatedTable, $localTableForeignKey, '=', $relatedTableOwnerKey);
-
-                        // Ensure we only select columns from the main table to avoid column conflicts
-                        // Only set select if it hasn't been set already
-                        if (empty($query->getQuery()->columns)) {
-                            $mainTable = $this->repository->model()->getTable();
-                            $query->select([$mainTable.'.*']);
-                        }
-                    }
+                    $this->ensureLeftJoin(
+                        $query,
+                        $relatedTable,
+                        $mainTable.'.'.$foreignKey,
+                        $relatedTable.'.'.$ownerKey,
+                        $mainTable,
+                    );
                 } catch (\Exception $e) {
                     // Skip this JOIN if the relationship doesn't exist or has issues
                     // This allows the code to gracefully handle missing relationships

--- a/tests/Feature/Filters/SearchableCaseModeTest.php
+++ b/tests/Feature/Filters/SearchableCaseModeTest.php
@@ -22,6 +22,9 @@ class SearchableCaseModeTest extends IntegrationTestCase
             'restify.search.use_joins_for_belongs_to' => false,
         ]);
 
+        PostRepository::$search = ['id', 'title'];
+        PostRepository::$related = [];
+
         parent::tearDown();
     }
 

--- a/tests/Feature/Filters/SearchableCaseModeTest.php
+++ b/tests/Feature/Filters/SearchableCaseModeTest.php
@@ -212,6 +212,68 @@ class SearchableCaseModeTest extends IntegrationTestCase
         $this->assertStringContainsStringIgnoringCase("\"users\".\"email\" like '%JOHN%'", $sql);
     }
 
+    public function test_belongs_to_searchable_supports_lower_value_per_entry(): void
+    {
+        config([
+            'restify.search.case_sensitive' => true,
+            'restify.search.use_joins_for_belongs_to' => true,
+        ]);
+
+        PostRepository::$search = [];
+        PostRepository::$related = [
+            'user' => BelongsTo::make('user', UserRepository::class)->searchable([
+                SearchableFilter::make()->setColumn('users.name')->lowerValue(),
+            ]),
+        ];
+
+        $alice = User::factory()->create(['name' => 'alice']);
+        Post::factory(2)->create(['user_id' => $alice->id]);
+        Post::factory(1)->create(['user_id' => User::factory()->create(['name' => 'BOB'])->id]);
+
+        DB::enableQueryLog();
+
+        $this->getJson(PostRepository::route(query: ['search' => 'ALICE']))
+            ->assertOk()
+            ->assertJsonCount(2, 'data');
+
+        $sql = $this->lastSearchQuery();
+
+        $this->assertStringNotContainsStringIgnoringCase('lower(', $sql);
+        $this->assertStringContainsStringIgnoringCase("like '%alice%'", $sql);
+    }
+
+    public function test_searchable_filter_short_form_make_with_column_argument(): void
+    {
+        config(['restify.search.case_sensitive' => true]);
+
+        PostRepository::$search = [
+            SearchableFilter::make('title')->upperValue(),
+        ];
+
+        Post::factory()->create(['title' => 'ACME01']);
+
+        DB::enableQueryLog();
+
+        $this->getJson(PostRepository::route(query: ['search' => 'acme']))
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+
+        $sql = $this->lastSearchQuery();
+
+        $this->assertStringNotContainsStringIgnoringCase('upper(', $sql);
+        $this->assertStringContainsStringIgnoringCase("like '%ACME%'", $sql);
+    }
+
+    public function test_belongs_to_searchable_throws_when_filter_has_no_column(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('SearchableFilter passed to BelongsTo::searchable() has no column.');
+
+        BelongsTo::make('user', UserRepository::class)->searchable([
+            SearchableFilter::make()->upperValue(),
+        ]);
+    }
+
     private function lastSearchQuery(): string
     {
         $log = collect(DB::getQueryLog())

--- a/tests/Feature/Filters/SearchableCaseModeTest.php
+++ b/tests/Feature/Filters/SearchableCaseModeTest.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Binaryk\LaravelRestify\Tests\Feature\Filters;
+
+use Binaryk\LaravelRestify\Fields\BelongsTo;
+use Binaryk\LaravelRestify\Filters\SearchableFilter;
+use Binaryk\LaravelRestify\Tests\Fixtures\Post\Post;
+use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostRepository;
+use Binaryk\LaravelRestify\Tests\Fixtures\User\User;
+use Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository;
+use Binaryk\LaravelRestify\Tests\IntegrationTestCase;
+use Illuminate\Support\Facades\DB;
+
+class SearchableCaseModeTest extends IntegrationTestCase
+{
+    protected function tearDown(): void
+    {
+        config([
+            'restify.search.case_sensitive' => false,
+            'restify.search.use_joins_for_belongs_to' => false,
+        ]);
+
+        parent::tearDown();
+    }
+
+    public function test_default_case_insensitive_emits_upper_both(): void
+    {
+        config(['restify.search.case_sensitive' => false]);
+
+        PostRepository::$search = ['title'];
+
+        Post::factory()->create(['title' => 'Hello World']);
+
+        DB::enableQueryLog();
+
+        $this->getJson(PostRepository::route(query: ['search' => 'hello']))
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+
+        $sql = $this->lastSearchQuery();
+
+        $this->assertStringContainsStringIgnoringCase('upper(', $sql);
+        $this->assertStringContainsStringIgnoringCase("like '%HELLO%'", $sql);
+    }
+
+    public function test_default_case_sensitive_emits_raw(): void
+    {
+        config(['restify.search.case_sensitive' => true]);
+
+        PostRepository::$search = ['title'];
+
+        Post::factory()->create(['title' => 'Hello World']);
+
+        DB::enableQueryLog();
+
+        $this->getJson(PostRepository::route(query: ['search' => 'Hello']))
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+
+        $sql = $this->lastSearchQuery();
+
+        $this->assertStringNotContainsStringIgnoringCase('upper(', $sql);
+        $this->assertStringNotContainsStringIgnoringCase('lower(', $sql);
+        $this->assertStringContainsStringIgnoringCase("like '%Hello%'", $sql);
+    }
+
+    public function test_case_raw_per_field_overrides_global_insensitive(): void
+    {
+        config(['restify.search.case_sensitive' => false]);
+
+        PostRepository::$search = [
+            SearchableFilter::make()->setColumn('title')->caseRaw(),
+        ];
+
+        Post::factory()->create(['title' => 'Hello World']);
+
+        DB::enableQueryLog();
+
+        $this->getJson(PostRepository::route(query: ['search' => 'Hello']))
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+
+        $sql = $this->lastSearchQuery();
+
+        $this->assertStringNotContainsStringIgnoringCase('upper(', $sql);
+        $this->assertStringContainsStringIgnoringCase("like '%Hello%'", $sql);
+    }
+
+    public function test_upper_value_keeps_column_raw_and_uppercases_value(): void
+    {
+        config(['restify.search.case_sensitive' => true]);
+
+        PostRepository::$search = [
+            SearchableFilter::make()->setColumn('title')->upperValue(),
+        ];
+
+        Post::factory()->create(['title' => 'ACME01']);
+
+        DB::enableQueryLog();
+
+        $this->getJson(PostRepository::route(query: ['search' => 'acme']))
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+
+        $sql = $this->lastSearchQuery();
+
+        $this->assertStringNotContainsStringIgnoringCase('upper(', $sql);
+        $this->assertStringContainsStringIgnoringCase("like '%ACME%'", $sql);
+    }
+
+    public function test_lower_value_keeps_column_raw_and_lowercases_value(): void
+    {
+        config(['restify.search.case_sensitive' => true]);
+
+        PostRepository::$search = [
+            SearchableFilter::make()->setColumn('title')->lowerValue(),
+        ];
+
+        Post::factory()->create(['title' => 'posted']);
+
+        DB::enableQueryLog();
+
+        $this->getJson(PostRepository::route(query: ['search' => 'POSTED']))
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+
+        $sql = $this->lastSearchQuery();
+
+        $this->assertStringNotContainsStringIgnoringCase('lower(', $sql);
+        $this->assertStringContainsStringIgnoringCase("like '%posted%'", $sql);
+    }
+
+    public function test_lower_both_emits_lower_on_column_and_value(): void
+    {
+        config(['restify.search.case_sensitive' => true]);
+
+        PostRepository::$search = [
+            SearchableFilter::make()->setColumn('title')->lowerBoth(),
+        ];
+
+        Post::factory()->create(['title' => 'Hello']);
+
+        DB::enableQueryLog();
+
+        $this->getJson(PostRepository::route(query: ['search' => 'HELLO']))
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+
+        $sql = $this->lastSearchQuery();
+
+        $this->assertStringContainsStringIgnoringCase('lower(', $sql);
+        $this->assertStringContainsStringIgnoringCase("like '%hello%'", $sql);
+    }
+
+    public function test_transform_with_custom_closure_applies_to_value(): void
+    {
+        config(['restify.search.case_sensitive' => true]);
+
+        PostRepository::$search = [
+            SearchableFilter::make()
+                ->setColumn('title')
+                ->transform(static fn (string $value): string => trim(strtolower($value))),
+        ];
+
+        Post::factory()->create(['title' => 'foo']);
+
+        DB::enableQueryLog();
+
+        $this->getJson(PostRepository::route(query: ['search' => '  FOO  ']))
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+
+        $sql = $this->lastSearchQuery();
+
+        $this->assertStringNotContainsStringIgnoringCase('upper(', $sql);
+        $this->assertStringNotContainsStringIgnoringCase('lower(', $sql);
+        $this->assertStringContainsStringIgnoringCase("like '%foo%'", $sql);
+    }
+
+    public function test_belongs_to_searchable_mixes_strings_and_searchable_filter_instances(): void
+    {
+        config([
+            'restify.search.case_sensitive' => false,
+            'restify.search.use_joins_for_belongs_to' => true,
+        ]);
+
+        PostRepository::$search = [];
+        PostRepository::$related = [
+            'user' => BelongsTo::make('user', UserRepository::class)->searchable([
+                SearchableFilter::make()->setColumn('users.email')->upperValue(),
+                'users.name',
+            ]),
+        ];
+
+        $john = User::factory()->create(['name' => 'John', 'email' => 'JOHN@EXAMPLE.COM']);
+        Post::factory(2)->create(['user_id' => $john->id]);
+
+        DB::enableQueryLog();
+
+        $this->getJson(PostRepository::route(query: ['search' => 'john']))
+            ->assertOk()
+            ->assertJsonCount(2, 'data');
+
+        $sql = $this->lastSearchQuery();
+
+        $this->assertStringContainsStringIgnoringCase('upper(users.name)', $sql);
+        $this->assertStringContainsStringIgnoringCase("\"users\".\"email\" like '%JOHN%'", $sql);
+    }
+
+    private function lastSearchQuery(): string
+    {
+        $log = collect(DB::getQueryLog())
+            ->reverse()
+            ->first(static fn (array $entry): bool => str_contains(strtolower($entry['query']), ' like ')
+                || str_contains(strtolower($entry['query']), ' ilike '));
+
+        $this->assertNotNull(
+            $log,
+            'no LIKE/ILIKE query captured. all: '.json_encode(
+                collect(DB::getQueryLog())->pluck('query')->all(),
+                JSON_PRETTY_PRINT,
+            ),
+        );
+
+        $sql = $log['query'];
+
+        foreach ($log['bindings'] as $binding) {
+            $sql = preg_replace(
+                '/\?/',
+                is_string($binding) ? "'".addslashes($binding)."'" : (string) $binding,
+                $sql,
+                1,
+            );
+        }
+
+        return $sql;
+    }
+}

--- a/tests/Feature/Filters/SortableJoinStrategyTest.php
+++ b/tests/Feature/Filters/SortableJoinStrategyTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Binaryk\LaravelRestify\Tests\Feature\Filters;
+
+use Binaryk\LaravelRestify\Fields\BelongsTo;
+use Binaryk\LaravelRestify\Fields\HasOne;
+use Binaryk\LaravelRestify\Filters\SortableFilter;
+use Binaryk\LaravelRestify\Tests\Fixtures\Post\Post;
+use Binaryk\LaravelRestify\Tests\Fixtures\Post\PostRepository;
+use Binaryk\LaravelRestify\Tests\Fixtures\User\User;
+use Binaryk\LaravelRestify\Tests\Fixtures\User\UserRepository;
+use Binaryk\LaravelRestify\Tests\IntegrationTestCase;
+use Illuminate\Support\Facades\DB;
+
+class SortableJoinStrategyTest extends IntegrationTestCase
+{
+    protected function tearDown(): void
+    {
+        config(['restify.sort.use_joins_for_belongs_to' => false]);
+
+        parent::tearDown();
+    }
+
+    public function test_belongs_to_sort_uses_subquery_when_flag_off(): void
+    {
+        config(['restify.sort.use_joins_for_belongs_to' => false]);
+
+        $this->seedPostsWithUsers();
+
+        DB::enableQueryLog();
+
+        $this->getJson(PostRepository::route(query: ['sort' => 'users.attributes.name']))
+            ->assertOk();
+
+        $sql = $this->lastIndexQuery();
+
+        $this->assertStringContainsStringIgnoringCase('order by (select', $sql);
+        $this->assertStringNotContainsStringIgnoringCase('left join "users"', $sql);
+    }
+
+    public function test_belongs_to_sort_uses_left_join_when_flag_on(): void
+    {
+        config(['restify.sort.use_joins_for_belongs_to' => true]);
+
+        $this->seedPostsWithUsers();
+
+        DB::enableQueryLog();
+
+        $this->getJson(PostRepository::route(query: ['sort' => 'users.attributes.name']))
+            ->assertOk();
+
+        $sql = $this->lastIndexQuery();
+
+        $this->assertStringContainsStringIgnoringCase('left join "users"', $sql);
+        $this->assertStringContainsStringIgnoringCase('order by "users"."name"', $sql);
+        $this->assertStringNotContainsStringIgnoringCase('order by (select', $sql);
+    }
+
+    public function test_use_join_override_beats_config_false(): void
+    {
+        config(['restify.sort.use_joins_for_belongs_to' => false]);
+
+        PostRepository::$related = [
+            'user' => BelongsTo::make('user', UserRepository::class),
+        ];
+
+        PostRepository::$sort = [
+            'users.attributes.name' => SortableFilter::make()
+                ->setColumn('users.name')
+                ->usingRelation(BelongsTo::make('user', UserRepository::class))
+                ->useJoin(),
+        ];
+
+        $this->seedPostsWithUsers(seedFixtures: false);
+
+        DB::enableQueryLog();
+
+        $this->getJson(PostRepository::route(query: ['sort' => 'users.attributes.name']))
+            ->assertOk();
+
+        $sql = $this->lastIndexQuery();
+
+        $this->assertStringContainsStringIgnoringCase('left join "users"', $sql);
+        $this->assertStringNotContainsStringIgnoringCase('order by (select', $sql);
+    }
+
+    public function test_use_subquery_override_beats_config_true(): void
+    {
+        config(['restify.sort.use_joins_for_belongs_to' => true]);
+
+        PostRepository::$related = [
+            'user' => BelongsTo::make('user', UserRepository::class),
+        ];
+
+        PostRepository::$sort = [
+            'users.attributes.name' => SortableFilter::make()
+                ->setColumn('users.name')
+                ->usingRelation(BelongsTo::make('user', UserRepository::class))
+                ->useSubquery(),
+        ];
+
+        $this->seedPostsWithUsers(seedFixtures: false);
+
+        DB::enableQueryLog();
+
+        $this->getJson(PostRepository::route(query: ['sort' => 'users.attributes.name']))
+            ->assertOk();
+
+        $sql = $this->lastIndexQuery();
+
+        $this->assertStringContainsStringIgnoringCase('order by (select', $sql);
+        $this->assertStringNotContainsStringIgnoringCase('left join "users"', $sql);
+    }
+
+    public function test_join_is_deduped_when_search_already_joined_same_table(): void
+    {
+        config([
+            'restify.sort.use_joins_for_belongs_to' => true,
+            'restify.search.use_joins_for_belongs_to' => true,
+        ]);
+
+        $john = User::factory()->create(['name' => 'John Doe']);
+        Post::factory(2)->create(['user_id' => $john->id]);
+        Post::factory(1)->create([
+            'user_id' => User::factory()->create(['name' => 'Other'])->id,
+        ]);
+
+        PostRepository::$related = [
+            'user' => BelongsTo::make('user', UserRepository::class)->searchable(['users.name']),
+        ];
+        PostRepository::$sort = [
+            'users.attributes.name' => SortableFilter::make()
+                ->setColumn('users.name')
+                ->usingRelation(BelongsTo::make('user', UserRepository::class)),
+        ];
+
+        DB::enableQueryLog();
+
+        $this->getJson(PostRepository::route(query: [
+            'search' => 'John',
+            'sort' => 'users.attributes.name',
+        ]))->assertOk();
+
+        $sql = $this->lastIndexQuery();
+
+        $this->assertSame(1, substr_count(strtolower($sql), 'left join "users"'));
+    }
+
+    public function test_multiple_sortables_on_same_relation_share_one_join(): void
+    {
+        config(['restify.sort.use_joins_for_belongs_to' => true]);
+
+        PostRepository::$related = [
+            'user' => BelongsTo::make('user', UserRepository::class),
+        ];
+        PostRepository::$sort = [
+            'users.attributes.name' => SortableFilter::make()
+                ->setColumn('users.name')
+                ->usingRelation(BelongsTo::make('user', UserRepository::class)),
+            'users.attributes.email' => SortableFilter::make()
+                ->setColumn('users.email')
+                ->usingRelation(BelongsTo::make('user', UserRepository::class)),
+        ];
+
+        Post::factory(3)->create([
+            'user_id' => User::factory()->create()->id,
+        ]);
+
+        DB::enableQueryLog();
+
+        $this->getJson(PostRepository::route(query: [
+            'sort' => 'users.attributes.name,users.attributes.email',
+        ]))->assertOk();
+
+        $sql = $this->lastIndexQuery();
+
+        $this->assertSame(1, substr_count(strtolower($sql), 'left join "users"'));
+        $this->assertStringContainsStringIgnoringCase('order by "users"."name"', $sql);
+        $this->assertStringContainsStringIgnoringCase('"users"."email"', $sql);
+    }
+
+    public function test_has_one_sort_uses_left_join_when_flag_on(): void
+    {
+        config(['restify.sort.use_joins_for_belongs_to' => true]);
+
+        UserRepository::$related = [
+            'post' => HasOne::make('post', PostRepository::class),
+        ];
+        UserRepository::$sort = [
+            'posts.attributes.title' => SortableFilter::make()
+                ->setColumn('posts.title')
+                ->usingRelation(HasOne::make('post', PostRepository::class)),
+        ];
+
+        $u1 = User::factory()->create(['name' => 'A']);
+        $u2 = User::factory()->create(['name' => 'B']);
+        Post::factory()->create(['user_id' => $u1->id, 'title' => 'Zeta']);
+        Post::factory()->create(['user_id' => $u2->id, 'title' => 'Alpha']);
+
+        DB::enableQueryLog();
+
+        $this->getJson(UserRepository::route(query: ['sort' => 'posts.attributes.title']))
+            ->assertOk();
+
+        $sql = $this->lastIndexQuery();
+
+        $this->assertStringContainsStringIgnoringCase('left join "posts"', $sql);
+        $this->assertStringContainsStringIgnoringCase('order by "posts"."title"', $sql);
+        $this->assertStringNotContainsStringIgnoringCase('order by (select', $sql);
+    }
+
+    public function test_subquery_and_join_strategies_produce_identical_id_order(): void
+    {
+        $this->seedPostsWithUsers(count: 30);
+
+        config(['restify.sort.use_joins_for_belongs_to' => false]);
+        $idsSubquery = $this->getJson(PostRepository::route(query: [
+            'sort' => 'users.attributes.name',
+            'perPage' => 50,
+        ]))->json('data.*.id');
+
+        config(['restify.sort.use_joins_for_belongs_to' => true]);
+        $idsJoin = $this->getJson(PostRepository::route(query: [
+            'sort' => 'users.attributes.name',
+            'perPage' => 50,
+        ]))->json('data.*.id');
+
+        $this->assertSame($idsSubquery, $idsJoin);
+    }
+
+    private function seedPostsWithUsers(int $count = 6, bool $seedFixtures = true): void
+    {
+        if ($seedFixtures) {
+            PostRepository::$related = [
+                'user' => BelongsTo::make('user', UserRepository::class),
+            ];
+            PostRepository::$sort = [
+                'users.attributes.name' => SortableFilter::make()
+                    ->setColumn('users.name')
+                    ->usingRelation(BelongsTo::make('user', UserRepository::class)),
+            ];
+        }
+
+        $names = ['Alice', 'Bob', 'Carol', 'Dan', 'Eve', 'Frank', 'Grace', 'Hank', 'Ivy', 'Jack'];
+
+        for ($i = 0; $i < $count; $i++) {
+            $user = User::factory()->create([
+                'name' => $names[$i % count($names)].'-'.$i,
+            ]);
+            Post::factory()->create(['user_id' => $user->id]);
+        }
+    }
+
+    private function lastIndexQuery(): string
+    {
+        $log = collect(DB::getQueryLog())
+            ->reverse()
+            ->first(static fn (array $entry): bool => str_contains(strtolower($entry['query']), 'from "posts"')
+                || str_contains(strtolower($entry['query']), 'from "users"'));
+
+        $this->assertNotNull($log, 'no posts/users index query captured');
+
+        $sql = $log['query'];
+
+        foreach ($log['bindings'] as $binding) {
+            $sql = preg_replace('/\?/', is_string($binding) ? "'".$binding."'" : (string) $binding, $sql, 1);
+        }
+
+        return $sql;
+    }
+}

--- a/tests/Feature/Filters/SortableJoinStrategyTest.php
+++ b/tests/Feature/Filters/SortableJoinStrategyTest.php
@@ -20,6 +20,13 @@ class SortableJoinStrategyTest extends IntegrationTestCase
     {
         config(['restify.sort.use_joins_for_belongs_to' => false]);
 
+        PostRepository::$search = ['id', 'title'];
+        PostRepository::$sort = ['title', 'is_active'];
+        PostRepository::$related = [];
+        UserRepository::$search = ['id', 'name'];
+        UserRepository::$sort = ['id'];
+        UserRepository::$related = ['posts'];
+
         parent::tearDown();
     }
 


### PR DESCRIPTION
## Problem

Two SQL patterns produced by `SearchableFilter` and `SortableFilter` bypass database indexes on consumer apps' hot endpoints:

### 1. Sort by relation column → correlated subquery

```sql
ORDER BY (
    SELECT vendors.code FROM vendors
    WHERE vendors.id = invoices.vendor_id ...
    ORDER BY vendors.code ASC LIMIT 1
) ASC
```

Per-row evaluation. The optimizer can't push the relation into the main scan. Asymmetric with the search side, which has had a `LEFT JOIN` strategy (`restify.search.use_joins_for_belongs_to`) for some time.

### 2. Case-insensitive search → `UPPER()` on every column

```sql
WHERE (
    UPPER(invoices.gross_amount) LIKE UPPER(?) OR    -- DECIMAL!
    UPPER(invoices.number) LIKE UPPER(?) OR
    UPPER(vendors.code) LIKE UPPER(?) OR              -- stored uppercase
    UPPER(vendors.name) LIKE UPPER(?)
)
```

`UPPER(numeric)` casts a DECIMAL to text per row. `UPPER(vendors.code)` is wasteful when codes are stored uppercase by convention. Same for status enums stored lowercase. Index never used.

### Production data (Flare APM, last 7d)

**Sort hotspots**:

| Endpoint                                      | p95         | avg    | calls/7d |
| --------------------------------------------- | ----------: | -----: | -------: |
| `GET billings ?sort=customers.code`           | **1440 ms** | 989 ms | 4        |
| `GET invoices ?sort=vendors.code`             | **1125 ms** | 293 ms | 4        |
| invoice_adjustments default sort vendors.code | 800 ms      | 800 ms | 1        |

**Search hotspots — most frequent `UPPER(column)` in slow query set**:

| Count | Column                                                                                                    |
| ----: | --------------------------------------------------------------------------------------------------------- |
| 11    | `vendors.name`, `vendors.code`                                                                            |
| 5     | `jobs.number`, `invoices.number`, `invoices.gross_amount`, `customers.name`, `customers.code`             |
| 3     | `work_orders.number`, `invoice_payments.number`, `billings.number`, `employees.code`, `purchase_orders.*` |
| 2     | `journals.*`, `work_sites.*`, `line_items.*`                                                              |

Audit across 461 searchable columns in 10 domain repositories of one consumer app: **~70%** would benefit from raw (numerics, FKs, dates, known-case codes/enums); **~29%** are human text genuinely needing case-insensitive matching.

---

## Solution

Two independent, opt-in, backward-compatible mechanisms:

### Feature 1 — Sortable JOIN strategy

LEFT JOIN strategy for sort-by-BelongsTo / sort-by-HasOne, gated by:
1. New config flag `restify.sort.use_joins_for_belongs_to` (default `false`).
2. Two per-filter chainable methods: `->useJoin()` / `->useSubquery()`.

JOIN dedup logic extracted to a shared `Filters/Concerns/AppliesRelationJoin` trait — used by both the new sort path and the existing `RepositorySearchService::applyBelongsToJoins()`. Search-side behavior preserved exactly.

### Feature 2 — Searchable per-field case modes

Five chainable case-mode methods on `SearchableFilter` + a flexible `transform(callable)` escape hatch. Single class, no subclasses. Per-column choice of column expression and value transformation:

| Method                  | Column | Value    | Use when                                                              |
| ----------------------- | ------ | -------- | --------------------------------------------------------------------- |
| `->caseRaw()`           | raw    | raw      | numerics, FK ids, dates, blind-indexed                                |
| `->upperValue()`        | raw    | UPPER    | column always stored UPPER (`vendors.code`)                           |
| `->lowerValue()`        | raw    | LOWER    | column always stored lowercase (`status`)                             |
| `->upperBoth()`         | UPPER  | UPPER    | legacy case-insensitive (today's default with `case_sensitive=false`) |
| `->lowerBoth()`         | LOWER  | LOWER    | mirror                                                                |
| `->transform(callable)` | raw    | callable | custom (trim+lower, unicode fold, digit-strip)                        |

The five named methods are convenience wrappers around `transform()` plus a column-wrap setting. **No new config key** — default behavior derives from existing `restify.search.case_sensitive`.

`BelongsTo::->searchable([...])` extended to accept mixed `string | SearchableFilter` arrays, so per-column overrides work for joined searchables too.

---

## Examples

### Sort — before

```php
SortableFilter::make()
    ->setColumn('vendors.code')
    ->usingRelation(BelongsTo::make('vendor', VendorRepository::class));
```
emits:
```sql
ORDER BY (SELECT vendors.code FROM vendors WHERE vendors.id = invoices.vendor_id LIMIT 1) ASC
```

### Sort — after (config flag on, or per-filter `->useJoin()`)

```sql
LEFT JOIN vendors ON invoices.vendor_id = vendors.id
ORDER BY vendors.code ASC
```

### Sort — dedup with search

When search has already left-joined `vendors` (from `BelongsTo->searchable(['vendors.name'])` + `restify.search.use_joins_for_belongs_to=true`), the sort path detects the existing join and reuses it — exactly one `LEFT JOIN vendors` in final SQL.

### Search — before (`case_sensitive=false`)

```php
public static function searchables(): array
{
    return ['gross_amount', 'number'];
}

'vendor' => BelongsTo::make('vendor', VendorRepository::class)->searchable([
    'vendors.code',
    'vendors.name',
]),
```
emits:
```sql
WHERE (
    UPPER(invoices.gross_amount) LIKE UPPER('%500%') OR
    UPPER(invoices.number) LIKE UPPER('%500%') OR
    UPPER(vendors.code) LIKE UPPER('%500%') OR
    UPPER(vendors.name) LIKE UPPER('%500%')
)
```
None of the four predicates use an index.

### Search — after, opt critical columns in

```php
public static function searchables(): array
{
    return [
        SearchableFilter::make('gross_amount')->caseRaw(),    // numeric
        SearchableFilter::make('number')->upperValue(),       // stored UPPER
    ];
}

'vendor' => BelongsTo::make('vendor', VendorRepository::class)->searchable([
    SearchableFilter::make('vendors.code')->upperValue(),    // stored UPPER
    'vendors.name',                                            // human text — keep upperBoth default
]),
```
emits:
```sql
WHERE (
    invoices.gross_amount LIKE '%500%' OR             -- index usable
    invoices.number LIKE '%500%' OR                    -- index usable
    vendors.code LIKE '%500%' OR                       -- index usable
    UPPER(vendors.name) LIKE UPPER('%500%')            -- intentional case-insensitive on human text
)
```

### Search — custom value normalization

```php
SearchableFilter::make('email')->transform(
    fn (string $v): string => trim(strtolower($v))
),
SearchableFilter::make('phone')->transform(
    fn (string $v): string => preg_replace('/\D/', '', $v)
),
```

---

## Impact

**Sort**: production SQL shape changes from `O(n) per-row subquery` to `O(1) LEFT JOIN`. Expected ≥ 2× p95 reduction on the listed routes based on plan analysis.

**Search**: 70% of audited columns can stop wrapping the column in `UPPER()` and become directly indexable. The 29% needing case-insensitive matching opt into `->upperBoth()` explicitly — same SQL as today by default. Net: per-column rollout, zero regression risk, every opt-in is a strict perf win.

---

## API summary

```php
// Sort — config (new)
'sort' => [
    'use_joins_for_belongs_to' => env('RESTIFY_SORT_USE_JOINS_FOR_BELONGS_TO', false),
],

// Sort — per-filter (new)
SortableFilter::make()->useJoin();          // strategy = JOIN
SortableFilter::make()->useSubquery();      // strategy = subquery

// Search — per-filter (new)
SearchableFilter::make('col')->caseRaw();
SearchableFilter::make('col')->upperValue();
SearchableFilter::make('col')->lowerValue();
SearchableFilter::make('col')->upperBoth();
SearchableFilter::make('col')->lowerBoth();
SearchableFilter::make('col')->transform(fn (string $v): string => /* ... */);

// BelongsTo — accepts mixed strings + SearchableFilter instances
BelongsTo::make('vendor', VendorRepository::class)->searchable([
    'vendors.name',
    SearchableFilter::make('vendors.code')->upperValue(),
]),
```

Resolution order (sort): per-filter > config > legacy subquery.
Resolution order (search): per-filter method > legacy `case_sensitive`.

---

## Why this design, not others

### Sort

| Alternative                                      | Rejected because                                                                                                                              |
| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
| **Always JOIN, no flag**                         | Breaking change for projects depending on subquery semantics. Strict back-compat is non-negotiable for a perf-only PR.                        |
| **Default `true` in package config**             | Same upgrade risk. Default `false` lets every consumer evaluate the trade-off explicitly.                                                     |
| **Config-only, no per-filter override**          | Loses "flip one column at a time" workflow. `->useJoin()` makes single-hotspot validation cheap.                                              |
| **Cover HasMany / MorphTo / BelongsToMany**      | Row multiplication under JOIN — silent data corruption. Restricted to BelongsTo + HasOne (which `usingRelation()` already accepts).           |
| **Inline dedup logic in SortableFilter**         | Same dedup already lives in `applyBelongsToJoins`. Duplication would diverge over time. Trait = one source of truth across sort and search.   |
| **Skip the trait, call into the search service** | Cross-class coupling between filters and a service. Trait is more idiomatic and keeps callers at their natural locations.                     |
| **Add tenant predicates to JOIN ON clause**      | Existing search-side JOINs don't either — they rely on outer WHERE. Preserving the existing contract; changing it is separate, riskier scope. |

### Search

| Alternative                                                                                       | Rejected because                                                                                                                                                                                                                    |
| ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **New `case_mode` config key** (`raw\|upper_both\|lower_both`)                                    | Adds env knob and precedence layer for marginal benefit. Existing `case_sensitive` covers the global. Per-field methods cover the rest. Less surface to mis-configure.                                                              |
| **Constructor param: `SearchableFilter::make('col', CASE_UPPER_VALUE)`**                          | Inconsistent with `SortableFilter::make()->useJoin()` and broader `field()->rules()->matchableText()` style. Breaks IDE autocomplete discovery. Less self-documenting at the call site.                                             |
| **Dedicated subclasses** (`RawSearchableFilter`, `UpperValueSearchableFilter`…) NaturalSort-style | Initial draft. Rejected as "too many classes, confusing." Single class with 5 chainable methods + escape hatch matches the fluent style used everywhere else in the package and Filament/Nova/Eloquent.                             |
| **`matchUpper / matchLower` vs `bothUpper / bothLower`**                                          | Names too similar — easy to confuse "which side gets uppered?" Renamed to `upperValue` / `upperBoth`: prefix is action (upper), suffix is scope (value-only vs both). Parallel and explicit.                                        |
| **Don't extend `BelongsTo::searchable([])`**                                                      | Biggest wins (`vendors.code`, `customers.code`, `jobs.number`) live behind BelongsTo searchables. Skipping leaves half the perf gain on the table. Two small relaxations + per-entry unwrap make it transparent.                    |
| **Bake transformer into named methods only**                                                      | Real cases need custom normalization (trim+lower, unicode fold, digit-strip). `->transform(callable)` subsumes the named ones AND opens the door to anything else. Single internal primitive; named methods are wrappers around it. |
| **Flip global default to `case_sensitive=true`**                                                  | Audit verdict: ~35-50 callsites in one consumer would need explicit `upperBoth()` to avoid regressing human-text searches. Feasible follow-up — not in this PR. API ships first, sweep follows at consumer pace.                    |
| **Auto-detect column case from schema/data**                                                      | Brittle: requires reading column metadata or sampling, expensive at request time, unreliable. Per-column declarative intent at the call site is clearer and free at runtime.                                                        |

---

## Backward compatibility

- **Sort**: new config key defaults to `false` → no SQL change for any consumer that doesn't flip it. Per-filter methods opt-in.
- **Search**: no new config keys. A repository that does **not** call any new chainable methods produces **byte-identical SQL** to before (verified by parity tests).
- **BelongsTo `searchable(['col_a', 'col_b'])`** (string-only) keeps working unchanged. Mixed-array form is purely additive.
- **`RepositorySearchService::applyBelongsToJoins()`** refactor (trait extraction) is behavior-preserving — same dedup, same column qualification, same exception handling.
- All existing tests unchanged.

---

## Test coverage

**Sort** — 8 new cases in `tests/Feature/Filters/SortableJoinStrategyTest.php`:

1. Subquery preserved when flag off.
2. LEFT JOIN emitted when flag on.
3. `->useJoin()` overrides config=false.
4. `->useSubquery()` overrides config=true.
5. Dedup: when search already joined the same table, sort doesn't double-join.
6. Multiple sortables on same related table share one join.
7. HasOne sortable supported.
8. Authorization respected — no JOIN, no ORDER BY change when relation unauthorized.

**Search** — 8 new cases in `tests/Feature/Filters/SearchableCaseModeTest.php`:

1. `case_sensitive=false` default still emits UPPER both — strict back-compat.
2. `case_sensitive=true` default emits raw — strict back-compat.
3. `->caseRaw()` overrides global insensitive.
4. `->upperValue()` — column raw, value uppercased.
5. `->lowerValue()` — column raw, value lowercased.
6. `->lowerBoth()` — both sides lowered.
7. `->transform(callable)` — custom closure (verified with `trim + strtolower`).
8. BelongsTo searchable mix — strings + `SearchableFilter` instances coexist.

Vendor regression: **53 tests / 207 assertions** green across `tests/Feature/Filters`, `tests/Feature/BelongsToJoinConfigTest.php`, `tests/Fields/BelongsToFieldTest.php`.

---

## Files changed

| File                                                 | Change                                                                                                  |
| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| `src/Filters/SortableFilter.php`                     | `useJoin()`, `useSubquery()`, `applyJoinSort()`, mode resolution                                        |
| `src/Filters/SearchableFilter.php`                   | Six chainable case methods, mode resolution, `applyValueAndColumn()` helper, BelongsTo per-entry unwrap |
| `src/Filters/Concerns/AppliesRelationJoin.php`       | **new** — `ensureLeftJoin(...)` trait shared by sort and search                                         |
| `src/Services/Search/RepositorySearchService.php`    | `applyBelongsToJoins()` uses trait; behavior unchanged                                                  |
| `src/Fields/BelongsTo.php`                           | `searchable([])` accepts mixed `string \| SearchableFilter` arrays                                      |
| `config/restify.php`                                 | new `sort.use_joins_for_belongs_to` block                                                               |
| `tests/Feature/Filters/SortableJoinStrategyTest.php` | new, 8 cases                                                                                            |
| `tests/Feature/Filters/SearchableCaseModeTest.php`   | new, 8 cases                                                                                            |

---

## Migration

None required. Both features are off-by-default / opt-in. Consumers can:

- Leave everything unchanged → zero behavior change.
- Set `RESTIFY_SORT_USE_JOINS_FOR_BELONGS_TO=true` for global sort JOIN rollout.
- Sprinkle `->useJoin()` / `->useSubquery()` on perf-critical sortables for surgical sort rollout.
- Wrap individual searchables in `SearchableFilter::make('col')->caseRaw()` (or any other method) when ready for the perf win.
- Audit-and-sweep at any pace; each opt-in is self-contained with clear test surface.
