### PR TITLE
feat: allow laravel/mcp ^0.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^8.3",
         "illuminate/contracts": "^11.0|^12.0|^13.0",
         "laravel/framework": "^11.0|^12.0|^13.0",
-        "laravel/mcp": "^0.4.1|^0.5|^0.6|^0.7|^0.8",
+        "laravel/mcp": "^0.4.1|^0.5|^0.6|^0.7|^0.8|^0.9",
         "laravel/pint": "^1.25.1",
         "spatie/laravel-data": "^4.4",
         "spatie/laravel-package-tools": "^1.12",


### PR DESCRIPTION
Widens the `laravel/mcp` constraint to include `^0.9`, allowing downstream apps to upgrade to laravel/mcp v0.9.x without dropping Restify.

Constraint only — no code changes.

Before: `^0.4.1|^0.5|^0.6|^0.7|^0.8`
After: `^0.4.1|^0.5|^0.6|^0.7|^0.8|^0.9`